### PR TITLE
Fix bugs as of 09/04/2024 and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Both single-threaded and multi-threaded programs are supported. All CPU architec
 
 ## Installation
 ### Requirements
-* Linux 5.8 or newer with [the ss command](https://man7.org/linux/man-pages/man8/ss.8.html)
+* Linux 5.8 or newer with [the ss command](https://man7.org/linux/man-pages/man8/ss.8.html) and compiled with ```CONFIG_DEBUG_INFO_BTF=y``` (or equivalent)
 * [Patched perf](https://gitlab.cern.ch/adaptiveperf/linux) compiled with Python support and the BPF skeletons
 * Python 3
 * CMake 3.9.6 or newer
@@ -45,7 +45,7 @@ Please clone this repository and run ```./build.sh``` (recommended: as non-root)
 AdaptivePerf is installed in ```/usr/local``` by default. If you want to change this path, specify it as an argument to ```install.sh```, e.g. ```./install.sh /usr```.
 
 ### Gentoo-based virtual machine image with frame pointers
-Given the complexity of setting up a machine with a recent enough Linux kernel, frame pointers, patched ```perf``` etc., we make available ready-to-use Gentoo-based qcow2 images with AdaptivePerf set up. They're also configured for out-of-the-box reliable ```perf``` profiling, such as permanently-set profiling-related kernel parameters and ensuring that everything in the system is compiled with frame pointers.
+Given the complexity of setting up a machine with a recent enough Linux kernel, frame pointers, patched ```perf``` etc., we make available ready-to-use x86 Gentoo-based qcow2 images with AdaptivePerf set up. They're also configured for out-of-the-box reliable ```perf``` profiling, such as permanently-set profiling-related kernel parameters and ensuring that everything in the system is compiled with frame pointers.
 
 The images are denoted by commit tags and can be downloaded from https://cernbox.cern.ch/s/FalGlNqzsdj0K5P.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Both single-threaded and multi-threaded programs are supported. All CPU architec
 
 ## Installation
 ### Requirements
-* Linux 5.8 or newer
+* Linux 5.8 or newer with [the ss command](https://man7.org/linux/man-pages/man8/ss.8.html)
 * [Patched perf](https://gitlab.cern.ch/adaptiveperf/linux) compiled with Python support and the BPF skeletons
 * Python 3
 * CMake 3.9.6 or newer

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 A comprehensive profiling tool with Linux ```perf``` as its main foundation.
 
 ## Recent redesign
-AdaptivePerf has been redesigned recently and its documentation and automated tests are not updated yet. This will change soon! In the meantime, testing is disabled and missing documentation parts are marked as "under construction".
+AdaptivePerf has been redesigned recently and its automated tests are not updated yet. This will change soon! In the meantime, testing is disabled.
 
 ## Disclaimer
-This is currently a beta version and the tool is under active development. The test coverage is currently limited and bugs are to be expected. Use at your own risk!
+This is currently a dev version and the tool is under active development. The test coverage is currently limited and bugs are to be expected. Use at your own risk!
 
 All feedback is welcome.
 
@@ -20,8 +20,9 @@ The project is distributed under the GNU GPL v2 license. See LICENSE for details
 * Profiling stack traces of functions spawning new threads/processes
 * Profiling any event supported by ```perf``` for sampling
 * Streaming profiling events in real-time through TCP to a different machine running adaptiveperf-server (part of this repository)
+* Detecting inappropriate CPU and kernel configurations automatically and therefore helping ```perf``` traverse stack completely in all cases
 
-Both single-threaded and multi-threaded programs are supported. All CPU architectures and vendors should also be supported (provided that the requirements are met) since the main features of AdaptivePerf are based on kernel-based performance counters and portable stack unwinding methods. However, if extra ```perf``` events are used for sampling, the list of available events should be checked beforehand by running ```perf list``` as this is architecture-dependent.
+Both single-threaded and multi-threaded programs are supported. All CPU architectures and vendors should also be supported (provided that the installation requirements are met, see below) since the main features of AdaptivePerf are based on kernel-based performance counters and portable stack traversal methods. However, if extra ```perf``` events are used for sampling, the list of available events should be checked beforehand by running ```perf list``` as this is architecture-dependent.
 
 ## Current limitations
 * Support for CPUs only (GPUs coming soon!)
@@ -40,7 +41,7 @@ Both single-threaded and multi-threaded programs are supported. All CPU architec
 Additionally, a profiled program along with dependencies should be compiled with frame pointers (i.e. with ```-fno-omit-frame-pointer``` and ```-mno-omit-leaf-frame-pointer``` flags in case of gcc). If you can, it is recommended to have everything in the system compiled with frame pointers (this can be achieved e.g. in Gentoo and Fedora 38+).
 
 ### Manually
-Please clone this repository and run ```./build.sh``` (recommended: as non-root) followed by ```./install.sh``` (required unless installing in a non-system prefix: as root).
+Please clone this repository and run ```./build.sh``` (as either non-root or root, non-root recommended) followed by ```./install.sh``` (as root unless you run the installation for a non-system prefix).
 
 AdaptivePerf is installed in ```/usr/local``` by default. If you want to change this path, specify it as an argument to ```install.sh```, e.g. ```./install.sh /usr```.
 
@@ -64,13 +65,21 @@ adaptiveperf "<command to be profiled>"
 ```
 (quoting is important if your command has whitespaces)
 
-You can specify extra perf events for sampling and adjust the sampling rate and the number of threads used for post-processing profiling data. See ```adaptiveperf --help``` for details (```man``` pages coming soon!).
+You can adjust profiling settings, e.g. specify extra perf events for sampling and change the sampling rate. See ```adaptiveperf --help``` for details (```man``` pages coming soon!).
 
 After profiling is completed, you can check the results inside ```results```.
 
 You can run ```adaptiveperf``` multiple times, all profiling results will be saved inside the same ```results``` directory provided that every ```adaptiveperf``` execution is done inside the same working directory.
 
 The structure of ```results``` is as follows:
-(under construction)
+* **(year)\_(month)\_(day)\_(hour)\_(minute)\_(second)\_(hostname)\_\_(command)**: the directory for a given profiling session
+  * **out**: the directory with output logs
+    * **perf\_(event)\_stdout.log, perf\_(event)\_stderr.log**: stdout and stderr logs from perf. (event) can be either "main" (on-CPU/off-CPU profiling), "syscall" (syscall profiling for tracing threads/processes), or a custom perf event specified by the user.
+    * **stdout.log, stderr.log**: stdout and stderr logs from the profiled command.
+    * **event\_dict.data**: mappings between custom perf events and their website titles as specified by the user (it is not created when no custom events are provided).
+  * **processed**: the directory with processed profiling information
+    * **metadata.json**: metadata (such as the thread/process tree and thread/process spawning stack traces) stored in JSON.
+    * **(event)\_callchains.json**: mappings between compressed callchain names and uncompressed ones stored in JSON. (event) can be either "walltime" (on-CPU/off-CPU profiling), "syscall" (syscall profiling for tracing threads/processes, applicable to metadata.json), or a custom perf event specified by the user.
+    * **(PID)\_(TID).json**: all samples gathered by on-CPU/off-CPU profiling and custom perf event profiling (if any) stored in JSON, per thread/process.
 
 It is recommended to use [AdaptivePerfHTML](https://github.com/AdaptivePerf/adaptiveperfhtml) for creating an interactive HTML summary of your profiling sessions.

--- a/src/root_command.sh
+++ b/src/root_command.sh
@@ -247,7 +247,7 @@ function perf_record() {
             done
         done
     else
-        IFS=':' read -ra addr_parts <<< "$1"
+        IFS=':' read -ra addr_parts <<< "$1"  # Based on https://stackoverflow.com/a/918931
         serv_addr=${addr_parts[0]}
         serv_port=${addr_parts[1]}
 
@@ -308,8 +308,7 @@ function perf_record() {
             continue
         fi
 
-        # Based on https://stackoverflow.com/a/918931
-        IFS=',' read -ra event_parts <<< "$ev"
+        IFS=',' read -ra event_parts <<< "$ev"  # Based on https://stackoverflow.com/a/918931
 
         if ! APERF_SERV_ADDR=$serv_addr APERF_SERV_PORT="${event_ports[@]:$start_index:$POST_PROCESSING_PARAM}" sudo -E taskset -c $PERF_MASK perf script adaptiveperf-process " -e ${event_parts[0]}/period=${event_parts[1]}/ --pid=$to_profile_pid" 1> $RESULT_OUT/perf_${event_parts[0]}_stdout.log 2> $RESULT_OUT/perf_${event_parts[0]}_stderr.log; then
             cp $RESULT_OUT/perf_${event_parts[0]}_*.log $CUR_DIR
@@ -336,7 +335,7 @@ function perf_record() {
             wait $i
         done
 
-        echo_sub "Profiled program has finished with non-zero exit code $code. This is expected if you have seen \"Profiling has failed\" errors. Exiting." 1
+        echo_sub "Profiled program or its wrapper has finished with non-zero exit code $code. This is expected if you have seen \"Profiling has failed\" errors. Exiting." 1
         exit 2
     fi
 

--- a/src/root_command.sh
+++ b/src/root_command.sh
@@ -11,7 +11,12 @@ TO_PROFILE="${args[command]}"
 
 cd /tmp/adaptiveperf.pid.$$
 
-trap 'rm -rf /tmp/adaptiveperf.pid.$$' EXIT
+function cleanup() {
+    pkill -P $$
+    rm -rf /tmp/adaptiveperf.pid.$$
+}
+
+trap 'cleanup' EXIT
 
 function print_notice() {
     echo "AdaptivePerf: comprehensive profiling tool based on Linux perf"

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -2,20 +2,23 @@
 set -e
 
 if [[ ! -n "$PERF_EXEC_PATH" ]]; then
-    if [[ -d /libexec/perf-core/scripts/python ]]; then
-	PERF_EXEC_PATH=/libexec/perf-core/scripts/python
-    elif [[ -d /usr/libexec/perf-core/scripts/python ]]; then
-	PERF_EXEC_PATH=/usr/libexec/perf-core/scripts/python
-    elif [[ -d /usr/local/libexec/perf-core/scripts/python ]]; then
-	PERF_EXEC_PATH=/usr/local/libexec/perf-core/scripts/python
+    perf_path=$(which perf)
+    if [[ -d /libexec/perf-core/scripts/python && $perf_path == /bin/* ]]; then
+        PERF_EXEC_PATH=/libexec/perf-core/scripts/python
+    elif [[ -d /usr/libexec/perf-core/scripts/python && $perf_path == /usr/bin/* ]]; then
+        PERF_EXEC_PATH=/usr/libexec/perf-core/scripts/python
+    elif [[ -d /usr/local/libexec/perf-core/scripts/python && $perf_path == /usr/local/bin/* ]]; then
+        PERF_EXEC_PATH=/usr/local/libexec/perf-core/scripts/python
     else
-	echo "perf with Python support is either not installed or installed in a custom directory!"
-	echo ""
-	echo "Please install it or set the PERF_EXEC_PATH environment variable to where Python"
-	echo "scripts for perf are stored (usually your perf setup prefix + libexec/perf-core/scripts/python)."
-	exit 1
+        >&2 echo "perf with Python support is either not installed or installed in a custom directory!"
+        >&2 echo ""
+        >&2 echo "Please install it or set the PERF_EXEC_PATH environment variable to where Python"
+        >&2 echo "scripts for perf are stored (usually your perf setup prefix + libexec/perf-core/scripts/python)."
+        exit 1
     fi
 fi
+
+echo "Your perf scripts directory is $PERF_EXEC_PATH."
 
 if [[ $1 == "uninstall" ]]; then
     rm $PERF_EXEC_PATH/bin/adaptiveperf-*

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -736,6 +736,8 @@ namespace aperf {
         }
       }
 
+      acceptor.close();
+
       for (int i = 0; i < threads.size(); i++) {
         try {
           threads[i].get();
@@ -744,8 +746,6 @@ namespace aperf {
           std::cerr << "get reliable results from them!" << std::endl;
         }
       }
-
-      acceptor.close();
     } catch (aperf::AlreadyInUseException &e) {
       throw e;
     } catch (aperf::SocketException &e) {

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -744,6 +744,8 @@ namespace aperf {
         } catch (aperf::SocketException &e) {
           std::cerr << "Warning: Socket error in client " << i << ", you will not ";
           std::cerr << "get reliable results from them!" << std::endl;
+
+          std::cerr << "Error details: " << e.what() << std::endl;
         }
       }
     } catch (aperf::AlreadyInUseException &e) {


### PR DESCRIPTION
Fixed bugs:
* Children are not cleaned up (e.g. internal adaptiveperf-server is not terminated in case of SIGINT) before AdaptivePerf exits.
* AdaptivePerf hangs when it connects to an unintended TCP server instead of its internal adaptiveperf-server.
* Errors from perf profilers are not handled clearly.
* The ERR trap in bash is not set properly (i.e. AdaptivePerf may crash with "unknown error" in situations when it shouldn't).
* One of the installation scripts doesn't detect the perf path correctly in case of several perf setups on the same machine.
* Some error messages are not clear.

Please note that whenever the internal adaptiveperf-server is mentioned, the adaptiveperf-server instance executed in case of running AdaptivePerf without the "-a" flag is meant.