### PR TITLE
[DRAFT] metric profiler integration

### DIFF
--- a/src/cmd/cmd.hpp
+++ b/src/cmd/cmd.hpp
@@ -22,33 +22,46 @@ namespace aperf {
     }
 
     std::string make_option_desc(const CLI::Option *opt) const override {
-      std::vector<std::string> parts;
-      boost::split(parts, opt->get_description(), boost::is_any_of(" "));
-
-      int characters_printed_in_line = 0;
       std::string result = "";
 
-      bool finish_with_new_line = false;
+      std::vector<std::string> lines;
+      boost::split(lines, opt->get_description(), boost::is_any_of("\n"));
 
-      for (int i = 0; i < parts.size(); i++) {
-        std::string to_print = parts[i];
+      for (int i = 0; i < lines.size(); i++) {
+        bool finish_with_new_line = false;
 
-        if (i < parts.size() - 1) {
-          to_print += " ";
+        if (!lines[i].empty()) {
+          std::vector<std::string> parts;
+          boost::split(parts, lines[i], boost::is_any_of(" "));
+
+          int characters_printed_in_line = 0;
+
+          for (int j = 0; j < parts.size(); j++) {
+            std::string to_print = parts[j];
+
+            if (j < parts.size() - 1) {
+              to_print += " ";
+            }
+
+            if (characters_printed_in_line > 0 &&
+                characters_printed_in_line + to_print.length() >=
+                80 - COLUMN_WIDTH) {
+              result += "\n";
+              characters_printed_in_line = 0;
+              finish_with_new_line = true;
+            }
+
+            result += to_print;
+            characters_printed_in_line += to_print.length();
+          }
         }
 
-        if (characters_printed_in_line > 0 &&
-            characters_printed_in_line + to_print.length() >= 80 - COLUMN_WIDTH) {
+        if (i < lines.size() - 1 || finish_with_new_line) {
           result += "\n";
-          characters_printed_in_line = 0;
-          finish_with_new_line = true;
         }
-
-        result += to_print;
-        characters_printed_in_line += to_print.length();
       }
 
-      return result + (finish_with_new_line ? "\n" : "");
+      return result;
     }
   };
 };

--- a/src/entrypoint.cpp
+++ b/src/entrypoint.cpp
@@ -41,27 +41,30 @@ namespace aperf {
     }
   };
 
-
-  std::vector<std::string> tokenize(const std::string& input, char delim) {
+  std::vector<std::string> tokenize(const std::string& input, char delim,
+                                    bool keep_quotes) {
     std::vector<std::string> tokens;
     std::string current_token;
     bool inside_quotes = false;
 
     for (char c : input) {
-        if (c == '"' && (current_token.empty() || current_token.back() != '\\')) {
-            inside_quotes = !inside_quotes;
-        } else if (c == delim && !inside_quotes) {
-            tokens.push_back(current_token);
-            current_token.clear();
-        } else {
-            current_token += c;
+      if (c == '"' && (current_token.empty() || current_token.back() != '\\')) {
+        inside_quotes = !inside_quotes;
+
+        if (keep_quotes) {
+          current_token += c;
         }
+      } else if (c == delim && !inside_quotes) {
+        tokens.push_back(current_token);
+        current_token.clear();
+      } else {
+        current_token += c;
+      }
     }
 
     tokens.push_back(current_token);
     return tokens;
-}
-
+  }
 
   /**
      Entry point to the AdaptivePerf frontend when it is run from
@@ -210,13 +213,12 @@ namespace aperf {
     )
       ->option_text("CONFIG")
       ->check([&metric_profilers_data](const std::string &arg) {
-
-        std::vector<std::string> matches_metric = tokenize(arg, ',');
+        std::vector<std::string> matches_metric = tokenize(arg, ',', true);
 
         SubcommandData metric_command_data = {"", "", 0, ""};
 
         for (std::string &option : matches_metric) {
-          std::vector<std::string> parsed_option = tokenize(option, ':');
+          std::vector<std::string> parsed_option = tokenize(option, ':', false);
           if (parsed_option.size() == 2) {
             if (parsed_option[0] == "c")
               if (metric_command_data.metric_command.empty()) {

--- a/src/entrypoint.cpp
+++ b/src/entrypoint.cpp
@@ -198,10 +198,10 @@ namespace aperf {
 
     std::vector<std::string> metric_strs;
     std::regex pattern_metric("");
-    app.add_option("-m,--metric", metric_strs, "Extra metric to sample  "
+    app.add_option("-m,--metric", metric_strs, "Extra metric to sample "
                    "based on an external profiler/metric command. ")
-      ->option_text("c:\"METRIC_COMAND\",n:\"METRIC_NAME\",f:SAMPLELING_FREQUENCY ( must "
-            "be a number),r:\"REGULAR_EXPRESSION\"")
+      ->option_text("c:\"METRIC_COMAND\",n:\"METRIC_NAME\",f:SAMPLELING_FREQUENCY"
+                    "(must be a number), r:\"REGULAR_EXPRESSION\"")
       ->take_all();
     
     CLI11_PARSE(app, argc, argv);
@@ -313,69 +313,75 @@ namespace aperf {
 
         SubcommandData metric_command_data = {"", "", 0, ""};
 
-        for (std::string &option : matches_metric){
-            std::vector<std::string> parsed_option = tokenize(option, ':');
-            if(parsed_option.size() == 2){
-                if(parsed_option[0] == "c")
-                if(metric_command_data.metric_command.empty()){
-                    metric_command_data.metric_command = parsed_option[1];
-                }else{
-                  print("Cannot specify multiple metric commands", true, true);
-                  return 2;
-                }
-                else if(parsed_option[0] == "n")
-                if(metric_command_data.metric_name.empty()){
-                    metric_command_data.metric_name = parsed_option[1];
-                }else{
-                  print("Cannot specify multiple metric names", true, true);
-                  return 2;
-                }
-                else if(parsed_option[0] == "f")
-                if(metric_command_data.frequency == 0){
-                try {
+        for (std::string &option : matches_metric) {
+          std::vector<std::string> parsed_option = tokenize(option, ':');
+          if (parsed_option.size() == 2) {
+            if (parsed_option[0] == "c")
+              if (metric_command_data.metric_command.empty()) {
+                metric_command_data.metric_command = parsed_option[1];
+              } else {
+                print("Cannot specify multiple metric commands", true, true);
+                return 2;
+              } 
+            else if (parsed_option[0] == "n")
+              if (metric_command_data.metric_name.empty()) {
+                metric_command_data.metric_name = parsed_option[1];
+              } else {
+                print("Cannot specify multiple metric names", true, true);
+                return 2;
+              }
+            else if (parsed_option[0] == "f")
+              if (metric_command_data.frequency == 0){
+                try
+                {
                   metric_command_data.frequency = std::stoi(parsed_option[1]);
                   if (metric_command_data.frequency < 0) {
-                      print("Cannot have negative frequency",true, true);
-                      return 2;
+                    print("Cannot have negative frequency", true, true);
+                    return 2;
                   }
-                  } catch (const std::invalid_argument& e) {
-                      print("Error: Invalid argument. Could not convert string to integer.", true, true);
-                      return 2;
-                  } catch (const std::out_of_range& e) {
-                      print("Error: Value out of range. ",true,true);
-                      return 2; 
-                  } 
-
-                }else{
-                  print("Cannot specify multiple frequencies for the metric", true, true);
+                } catch (const std::invalid_argument &e) {
+                  print("Error: Invalid argument. Could not convert string to integer.", true, true);
+                  return 2;
+                } catch (const std::out_of_range &e) {
+                  print("Error: Value out of range. ", true, true);
                   return 2;
                 }
-                else if(parsed_option[0] == "r")
-                if(metric_command_data.regular_expression.empty()){
-                    metric_command_data.regular_expression = parsed_option[1];
-                }else{
-                  print("Cannot specify multiple regular expressions for one metric command", true, true);
+                if (metric_command_data.frequency == 0) {
+                  print("Cannot set frequency value to 0.",true,true);
                   return 2;
                 }
-                else{
-                  print("Metric command option not recognised.", true, true);
-                  return 2;
-                }
-              
-            }else{
-                print("Cannot parse option for metric command (too many or too little agruments were given)", true, true);
+              } else {
+                print("Cannot specify multiple frequencies for the metric", true, true);
                 return 2;
+              }
+            else if (parsed_option[0] == "r")
+              if (metric_command_data.regular_expression.empty()) {
+                metric_command_data.regular_expression = parsed_option[1];
+              } else {
+                print("Cannot specify multiple regular expressions for one metric command", true, true);
+                return 2;
+              } else {
+              print("Metric command option not recognised.", true, true);
+              return 2;
             }
-        }
-        if (metric_command_data.metric_command.empty()){
-            print("Metric command needs to be specified", true, true);
+          } else {
+            print("Cannot parse option for metric command (too many or too little agruments were given)", true, true);
             return 2;
-        }else{
-          if(metric_command_data.frequency == 0 ){
-            metric_command_data.frequency == 10;
           }
-          profilers.push_back(std::make_unique<MetricReader>(metric_command_data.metric_command, metric_command_data.metric_name, metric_command_data.frequency, metric_command_data.regular_expression, server_buffer));
         }
+        if (metric_command_data.metric_command.empty()) {
+          print("Metric command needs to be specified", true, true);
+          return 2;
+        }
+        if (metric_command_data.metric_name.empty()) {
+          print("Metric name needs to be specified", true, true);
+          return 2;
+        }
+        if (metric_command_data.frequency == 0) {
+          metric_command_data.frequency = 10;
+        }
+
+        profilers.push_back(std::make_unique<MetricReader>(metric_command_data.metric_command, metric_command_data.metric_name, metric_command_data.frequency, metric_command_data.regular_expression, server_buffer));
       }
 
       pid_t current_pid = getpid();

--- a/src/entrypoint.cpp
+++ b/src/entrypoint.cpp
@@ -199,9 +199,11 @@ namespace aperf {
     std::vector<std::string> metric_strs;
     std::regex pattern_metric("");
     app.add_option("-m,--metric", metric_strs, "Extra metric to sample "
-                   "based on an external profiler/metric command. ")
-      ->option_text("c:\"METRIC_COMAND\",n:\"METRIC_NAME\",f:SAMPLELING_FREQUENCY"
-                    "(must be a number), r:\"REGULAR_EXPRESSION\"")
+                   "based on an external profiler/metric command. Usage: -m "
+                   "c:\"METRIC_COMAND\",n:\"METRIC_NAME\",f:SAMPLELING_FREQUENCY"
+                    "(must be a number), r:\"REGULAR_EXPRESSION\""
+                   )
+      ->option_text("CONFIG")
       ->take_all();
     
     CLI11_PARSE(app, argc, argv);

--- a/src/server/subclient.cpp
+++ b/src/server/subclient.cpp
@@ -291,6 +291,25 @@ namespace aperf {
                     true, event_type == "offcpu-time");
 
             res.total_period += period;
+          }else if(arr[0] == "<CUSTOM_METRIC>"){
+            std::string metric_command, metric_name;
+            long timestamp;
+            float metric_val;
+            try {
+              metric_command = arr[1];
+              metric_name = arr[2];
+              timestamp = arr[3];
+              metric_val = arr[4];
+
+              nlohmann::json metric = nlohmann::json::array({"<CUSTOM_METRIC>",
+              metric_command, metric_name, timestamp, metric_val});
+
+              std::string s = metric.dump();
+              std::cout << s << std::endl;
+            } catch (...) {
+              std::cerr << "The recently received sample JSON is invalid, ignoring." << std::endl;
+              continue;
+            }
           }
         }
       }

--- a/src/server/subclient.cpp
+++ b/src/server/subclient.cpp
@@ -291,7 +291,7 @@ namespace aperf {
                     true, event_type == "offcpu-time");
 
             res.total_period += period;
-          }else if(arr[0] == "<CUSTOM_METRIC>"){
+          } else if (arr[0] == "<CUSTOM_METRIC>") {
             std::string metric_command, metric_name;
             long timestamp;
             float metric_val;
@@ -302,7 +302,7 @@ namespace aperf {
               metric_val = arr[4];
 
               nlohmann::json metric = nlohmann::json::array({"<CUSTOM_METRIC>",
-              metric_command, metric_name, timestamp, metric_val});
+                  metric_command, metric_name, timestamp, metric_val});
 
               std::string s = metric.dump();
               std::cout << s << std::endl;


### PR DESCRIPTION
1. Added a command-line option allowing the user to specify that they want AdaptivePerf to process metric data from command X executed Y times per second.
2. Added an object of the MetricReader class to the profiler list passed to start_profiling_session().
3. Subclient now prints one line in the form below to stdout whenever a <CUSTOM_METRIC> JSON array is received.

For now multiple metric subcommands is not working.