### PR TITLE
added start_time for each thread in thread json file

### DIFF
--- a/src/server/client.cpp
+++ b/src/server/client.cpp
@@ -155,7 +155,7 @@ namespace aperf {
                     metadata["sampled_times"][elem2.key()].swap(elem3.value());
                   } else if (elem3.key() == "offcpu_regions") {
                     metadata["offcpu_regions"][elem2.key()].swap(elem3.value());
-                  } else if (elem3.key() != "first_time") {
+                  } else {
                     final_output[elem2.key()][elem3.key()].swap(elem3.value());
                   }
                 }


### PR DESCRIPTION
This is needed in order to know exact starting time of each function.