### PR TITLE
Add support for user-source-code-level profiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,10 @@ if(COMMAND cmake_policy)
   if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24")
     cmake_policy(SET CMP0135 NEW)
   endif()
+
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.30")
+    cmake_policy(SET CMP0167 NEW)
+  endif()
 endif()
 
 option(SERVER_ONLY "Compile only adaptiveperf-server (OS-portable)" OFF)
@@ -90,6 +94,10 @@ if(NOT SERVER_ONLY)
   target_compile_definitions(main_entrypoint.o PRIVATE APERF_CONFIG_FILE="${APERF_CONFIG_PATH}")
 
   find_package(Boost REQUIRED program_options)
+
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.30")
+    message(STATUS "Found Boost: headers inside ${Boost_INCLUDE_DIRS}, version ${Boost_VERSION_STRING}")
+  endif()
 
   target_link_libraries(adaptiveperf PRIVATE nlohmann_json::nlohmann_json)
   target_link_libraries(adaptiveperf PRIVATE Poco::Foundation Poco::Net)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ else()
     LANGUAGES CXX)
 endif()
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -89,6 +89,7 @@ if(NOT SERVER_ONLY)
   add_library(profilers.o OBJECT src/profilers.cpp)
   add_library(profiling.o OBJECT src/profiling.cpp)
   add_library(requirements.o OBJECT src/requirements.cpp)
+  add_library(archive.o OBJECT src/archive.cpp)
 
   target_compile_definitions(profilers.o PRIVATE APERF_SCRIPT_PATH="${APERF_SCRIPT_PATH}")
   target_compile_definitions(main_entrypoint.o PRIVATE APERF_CONFIG_FILE="${APERF_CONFIG_PATH}")
@@ -99,15 +100,19 @@ if(NOT SERVER_ONLY)
     message(STATUS "Found Boost: headers inside ${Boost_INCLUDE_DIRS}, version ${Boost_VERSION_STRING}")
   endif()
 
+  find_package(LibArchive REQUIRED)
+
   target_link_libraries(adaptiveperf PRIVATE nlohmann_json::nlohmann_json)
   target_link_libraries(adaptiveperf PRIVATE Poco::Foundation Poco::Net)
   target_link_libraries(adaptiveperf PRIVATE CLI11::CLI11)
   target_link_libraries(adaptiveperf PRIVATE Boost::program_options)
+  target_link_libraries(adaptiveperf PRIVATE LibArchive::LibArchive)
 
   target_include_directories(adaptiveperf PRIVATE ${nlohmann_json_INCLUDE_DIRS})
   target_include_directories(adaptiveperf PRIVATE ${Poco_INCLUDE_DIRS})
   target_include_directories(adaptiveperf PRIVATE ${CLI11_INCLUDE_DIRS})
   target_include_directories(adaptiveperf PRIVATE ${Boost_INCLUDE_DIRS})
+  target_include_directories(adaptiveperf PRIVATE ${LibArchive_INCLUDE_DIRS})
 
   find_library(LIBNUMA
     NAMES numa
@@ -142,7 +147,7 @@ if(NOT SERVER_ONLY)
 
   target_link_libraries(adaptiveperf PRIVATE aperfserv)
   target_link_libraries(adaptiveperf PRIVATE
-    profiling.o requirements.o profilers.o print.o main_entrypoint.o version.o)
+    profiling.o requirements.o profilers.o print.o archive.o main_entrypoint.o version.o)
 endif()
 
 if (ENABLE_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ if(NOT SERVER_ONLY)
   add_library(profiling.o OBJECT src/profiling.cpp)
   add_library(requirements.o OBJECT src/requirements.cpp)
   add_library(archive.o OBJECT src/archive.cpp)
+  add_library(process.o OBJECT src/process.cpp)
 
   target_compile_definitions(profilers.o PRIVATE APERF_SCRIPT_PATH="${APERF_SCRIPT_PATH}")
   target_compile_definitions(main_entrypoint.o PRIVATE APERF_CONFIG_FILE="${APERF_CONFIG_PATH}")
@@ -147,7 +148,7 @@ if(NOT SERVER_ONLY)
 
   target_link_libraries(adaptiveperf PRIVATE aperfserv)
   target_link_libraries(adaptiveperf PRIVATE
-    profiling.o requirements.o profilers.o print.o archive.o main_entrypoint.o version.o)
+    profiling.o requirements.o profilers.o print.o archive.o main_entrypoint.o process.o version.o)
 endif()
 
 if (ENABLE_TESTS)

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ By default, the full suite is installed, i.e. ```adaptiveperf``` and ```adaptive
   * If you want complete kernel debug symbols, ```CONFIG_KALLSYMS=y``` and ```CONFIG_KALLSYMS_ALL=y``` (or equivalent) should also be set.
   * **Kernel recompilation may NOT be needed! If you have ```/sys/kernel/btf``` and ```/sys/kernel/tracing/events/syscalls``` as explained above and you don't care about having kernel debug symbols, you're already good to go here!**
 * Python 3
+* addr2line (part of binutils)
 * CMake 3.20 or newer (if building from source)
 * libnuma (if a machine with your profiled application has NUMA)
 * [CLI11](https://github.com/CLIUtils/CLI11) (if building from source)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Work is being done towards eliminating all of the limitations below step-by-step
 * No support for non-CPU devices such as GPUs
 * No support for partial profiling
 * No API for profiling result analysis (only flame graphs can be produced right now)
-* No profiling with line number / compiler IR / assembly details
+* No profiling with ~~line number /~~ compiler IR / assembly details (profiling with user-source-code-level information is supported now)
 
 ## Installation
 ### Requirements
@@ -87,6 +87,8 @@ If you want to install just adaptiveperf-server, please clone this repository an
 ```./install.sh``` supports a custom installation prefix, see the "Manually" section above. adaptiveperf-server does not require the patched "perf" and should be compilable for various operating systems (the scripts are only tested on Linux though).
 
 ### Gentoo-based virtual machine image with frame pointers
+**WARNING: There is an issue with the CI/CD pipeline causing the VM images to be corrupted, so this installation option is not available now. Please use Docker/Apptainer/Singularity container images instead. This note will disappear when the problem is fixed. Sorry for the inconvenience!**
+
 Given the complexity of setting up a machine with a recent enough Linux kernel, frame pointers etc., we make available ready-to-use x86-64 Gentoo-based qcow2 images with AdaptivePerf set up. They're also configured for out-of-the-box reliable ```perf``` profiling, such as permanently-set profiling-related kernel parameters and ensuring that everything in the system is compiled with frame pointers.
 
 The images are denoted either by "latest" (which corresponds to the latest commit in the ```main``` branch and **is recommended until the first non-dev release**) or by branch names and can be downloaded from https://cernbox.cern.ch/s/FAzoFWvh2kzNtUx. They must be booted in the UEFI mode.

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -1,0 +1,252 @@
+// AdaptivePerf: comprehensive profiling tool based on Linux perf
+// Copyright (C) CERN. See LICENSE for details.
+
+#include "archive.hpp"
+#include <fstream>
+
+namespace aperf {
+  Archive::Archive(fs::path path, unsigned int buf_size) {
+    this->arch = nullptr;
+    this->arch_entry = nullptr;
+    this->buf_size = buf_size;
+
+    if (fs::exists(path)) {
+      throw Archive::FileExistsException();
+    }
+
+    this->arch = archive_write_new();
+
+    if (!this->arch) {
+      throw Archive::InitException();
+    }
+
+    this->arch_entry = archive_entry_new();
+
+    if (!this->arch_entry) {
+      throw Archive::InitException();
+    }
+
+    if (archive_write_set_format_zip(this->arch) != ARCHIVE_OK) {
+      throw Archive::InitException();
+    }
+
+    if (archive_write_set_options(this->arch, "compression-level=9") !=
+        ARCHIVE_OK) {
+      throw Archive::InitException();
+    }
+
+    if (archive_write_open_filename(this->arch, path.c_str()) != ARCHIVE_OK) {
+      throw Archive::FileOpenException(this->arch);
+    }
+  }
+
+  Archive::Archive(std::unique_ptr<Connection> &conn, bool padding,
+                   unsigned int buf_size) {
+    this->arch = nullptr;
+    this->arch_entry = nullptr;
+    this->buf_size = buf_size;
+    this->conn = std::move(conn);
+
+    this->arch = archive_write_new();
+
+    if (!this->arch) {
+      throw Archive::InitException();
+    }
+
+    this->arch_entry = archive_entry_new();
+
+    if (!this->arch_entry) {
+      throw Archive::InitException();
+    }
+
+    if (archive_write_set_format_zip(this->arch) != ARCHIVE_OK) {
+      throw Archive::InitException();
+    }
+
+    if (archive_write_set_options(this->arch, "compression-level=9") !=
+        ARCHIVE_OK) {
+      throw Archive::InitException();
+    }
+
+    auto archive_open_padding =
+      [](struct archive *arch, void *data) -> int {
+        return archive_write_set_bytes_in_last_block(arch, 0);
+      };
+
+    auto archive_open_no_padding =
+      [](struct archive *arch, void *data) -> int {
+        return archive_write_set_bytes_in_last_block(arch, 1);
+      };
+
+    auto archive_return_ok =
+      [](struct archive *arch, void *data) -> int {
+        return ARCHIVE_OK;
+      };
+
+    auto archive_write =
+      [](struct archive *arch, void *data, const void *buf,
+         size_t len) -> la_ssize_t {
+        try {
+          ((Connection *)data)->write(len, (char *)buf);
+          return len;
+        } catch (std::exception &e) {
+          archive_set_error(arch, ARCHIVE_FAILED, "%s", e.what());
+          return -1;
+        }
+      };
+
+    if (archive_write_open2(this->arch, this->conn.get(),
+                            padding ?
+                            archive_open_padding : archive_open_no_padding,
+                            archive_write,
+                            archive_return_ok,
+                            archive_return_ok) != ARCHIVE_OK) {
+      throw Archive::FileOpenException(this->arch);
+    }
+  }
+
+  void Archive::add_file(std::string filename, fs::path path) {
+    if (!this->arch) {
+      throw Archive::AlreadyClosedException();
+    }
+
+    if (!fs::exists(path)) {
+      throw Archive::FileDoesNotExistException();
+    }
+
+    if (!fs::is_regular_file(path)) {
+      throw Archive::NotRegularFileException();
+    }
+
+    archive_entry_clear(this->arch_entry);
+
+    std::ifstream stream(path);
+
+    if (!stream) {
+      throw Archive::FileOpenException();
+    }
+
+    archive_entry_set_pathname(this->arch_entry, filename.c_str());
+    archive_entry_set_size(this->arch_entry, fs::file_size(path));
+    archive_entry_set_filetype(this->arch_entry, AE_IFREG);
+    archive_entry_set_perm(this->arch_entry, 0644);
+
+    auto now = std::chrono::system_clock::now().time_since_epoch();
+    time_t secs = std::chrono::duration_cast<std::chrono::seconds>(now).count();
+
+    archive_entry_set_atime(this->arch_entry, secs, 0);
+    archive_entry_set_birthtime(this->arch_entry, secs, 0);
+    archive_entry_set_ctime(this->arch_entry, secs, 0);
+    archive_entry_set_mtime(this->arch_entry, secs, 0);
+
+    if (archive_write_header(this->arch, this->arch_entry) != ARCHIVE_OK) {
+      throw Archive::FileIOException(this->arch);
+    }
+
+    char buf[this->buf_size];
+    int bytes_read;
+
+    while (!stream.fail() &&
+           (bytes_read = stream.readsome(buf, this->buf_size)) > 0) {
+      int bytes_written = archive_write_data(this->arch, buf, bytes_read);
+      if (bytes_written == -1) {
+        throw Archive::FileIOException(this->arch);
+      } else if (bytes_written != bytes_read) {
+        throw Archive::FileIOException();
+      }
+    }
+
+    if (stream.fail()) {
+      throw Archive::FileIOException();
+    }
+  }
+
+  void Archive::add_file_stream(std::string filename, std::istream &stream,
+                                unsigned int size) {
+    if (!this->arch) {
+      throw Archive::AlreadyClosedException();
+    }
+
+    archive_entry_clear(this->arch_entry);
+
+    archive_entry_set_pathname(this->arch_entry, filename.c_str());
+    archive_entry_set_size(this->arch_entry, size);
+    archive_entry_set_filetype(this->arch_entry, AE_IFREG);
+    archive_entry_set_perm(this->arch_entry, 0644);
+
+    auto now = std::chrono::system_clock::now().time_since_epoch();
+    time_t secs = std::chrono::duration_cast<std::chrono::seconds>(now).count();
+
+    archive_entry_set_atime(this->arch_entry, secs, 0);
+    archive_entry_set_birthtime(this->arch_entry, secs, 0);
+    archive_entry_set_ctime(this->arch_entry, secs, 0);
+    archive_entry_set_mtime(this->arch_entry, secs, 0);
+
+    if (archive_write_header(this->arch, this->arch_entry) != ARCHIVE_OK) {
+      throw Archive::FileIOException(this->arch);
+    }
+
+    char buf[this->buf_size];
+    int bytes_read;
+    int total_bytes = 0;
+
+    while (!stream.fail() &&
+           (bytes_read = stream.readsome(buf, std::min(std::max(0, (int)size - total_bytes), (int)this->buf_size))) > 0) {
+      int bytes_written = archive_write_data(this->arch, buf, bytes_read);
+      if (bytes_written == -1) {
+        throw Archive::FileIOException(this->arch);
+      } else if (bytes_written != bytes_read) {
+        throw Archive::FileIOException();
+      }
+
+      total_bytes += bytes_read;
+    }
+
+    if (stream.fail()) {
+      throw Archive::FileIOException();
+    }
+
+    if (total_bytes < size) {
+      int zeroes_written = 0;
+
+      while (zeroes_written < size - total_bytes) {
+        int to_write = (size - total_bytes - zeroes_written) % (this->buf_size + 1);
+
+        for (int i = 0; i < to_write; i++) {
+          buf[i] = 0;
+        }
+
+        int bytes_written = archive_write_data(this->arch, buf, to_write);
+        if (bytes_written == -1) {
+          throw Archive::FileIOException(this->arch);
+        } else if (bytes_written != to_write) {
+          throw Archive::FileIOException();
+        }
+
+        zeroes_written += to_write;
+      }
+    }
+  }
+
+  void Archive::close() {
+    if (this->arch) {
+      if (archive_write_close(this->arch) != ARCHIVE_OK) {
+        throw Archive::CloseException(this->arch);
+      }
+
+      archive_write_free(this->arch);
+
+      this->arch = nullptr;
+    }
+  }
+
+  Archive::~Archive() {
+    if (this->arch_entry) {
+      archive_entry_free(this->arch_entry);
+    }
+
+    if (this->arch) {
+      archive_write_free(this->arch);
+    }
+  }
+};

--- a/src/archive.hpp
+++ b/src/archive.hpp
@@ -1,0 +1,119 @@
+// AdaptivePerf: comprehensive profiling tool based on Linux perf
+// Copyright (C) CERN. See LICENSE for details.
+
+#ifndef ARCHIVE_HPP_
+#define ARCHIVE_HPP_
+
+#include "server/socket.hpp"
+#include <filesystem>
+#include <istream>
+#include <archive.h>
+#include <archive_entry.h>
+
+namespace aperf {
+  namespace fs = std::filesystem;
+
+  /**
+     A class describing an archive file to be written to.
+  */
+  class Archive {
+  private:
+    struct archive *arch;
+    struct archive_entry *arch_entry;
+    unsigned int buf_size;
+    std::unique_ptr<Connection> conn;
+
+  public:
+    /**
+       Constructs an Archive object and opens a file for writing.
+
+       When the object is destructed, the file is guaranteed to be properly
+       closed, but without any promises about whether all remaining data
+       have been written. Therefore, you should explicitly call close()
+       (which may throw an exception) before the object goes out of scope.
+
+       @param path     The path to an archive file to be created. The file
+                       must not exist yet.
+       @param buf_size A number of bytes of the internal buffers.
+    */
+    Archive(fs::path path, unsigned int buf_size = 1024);
+
+    /**
+       Constructs an Archive object with all archive file data to be sent
+       through a Connection object.
+
+       When the object is destructed, the connection is guaranteed to be
+       properly closed and all remaining data are guaranteed to have been written.
+       Therefore, you *DO NOT* need to call close() before the object goes out of
+       scope or anywhere else.
+
+       @param conn     A Connection object which all archive file data
+                       will be sent through.
+       @param padding  Whether padding is allowed to be added to the last block
+                       of the archive file data if necessary. If you are not
+                       sure, this should be set to true (default).
+       @param buf_size A number of bytes of the internal buffers.
+    */
+    Archive(std::unique_ptr<Connection> &conn, bool padding = true,
+            unsigned int buf_size = 1024);
+
+    /**
+       Adds a file to the root of the archive file.
+
+       @param filename The name of a file that will appear inside the archive.
+       @param path     The path to a file to be added to the archive. The file
+                       must be a regular file and not a directory.
+    */
+    void add_file(std::string filename, fs::path path);
+
+    /**
+       Saves data extracted from a stream to the root of the archive file
+       as a regular file.
+
+       @param filename The name of a file that will appear inside the archive.
+       @param stream   A stream containing data to be saved to the archive.
+       @param size     A number of bytes to save to the archive. If it's larger
+                       than the actual file size, the entire file will be added,
+                       followed by padding with zeroes.
+    */
+    void add_file_stream(std::string filename, std::istream &stream,
+                         unsigned int size);
+
+    /**
+       Closes the file/connection and makes sure that all remaining data have
+       been written.
+    */
+    void close();
+
+    ~Archive();
+
+    class Exception : public std::exception {
+    private:
+      const char *message;
+
+    public:
+      Exception(struct archive *arch) {
+        this->message = archive_error_string(arch);
+      }
+
+      Exception() {
+        this->message = typeid(*this).name();
+      }
+
+      const char *what() const noexcept override {
+        return this->message;
+      }
+    };
+
+    class InitException : public Exception { using Exception::Exception; };
+    class FileExistsException : public Exception { using Exception::Exception; };
+    class FileOpenException : public Exception { using Exception::Exception; };
+    class FileIOException : public Exception { using Exception::Exception; };
+    class CloseException : public Exception { using Exception::Exception; };
+    class AlreadyClosedException : public Exception { using Exception::Exception; };
+    class FileDoesNotExistException : public Exception { using Exception::Exception; };
+    class NotRegularFileException : public Exception { using Exception::Exception; };
+  };
+};
+
+#endif

--- a/src/entrypoint.cpp
+++ b/src/entrypoint.cpp
@@ -282,6 +282,14 @@ namespace aperf {
       profilers.push_back(std::make_unique<Perf>(perf_path, main, cpu_config,
                                                  "On-CPU/Off-CPU profiler"));
 
+      PipeAcceptor::Factory generic_acceptor_factory;
+
+      for (int i = 0; i < profilers.size(); i++) {
+        std::unique_ptr<Acceptor> acceptor =
+          generic_acceptor_factory.make_acceptor(1);
+        profilers[i]->set_acceptor(acceptor, server_buffer);
+      }
+
       std::unordered_map<std::string, std::string> event_dict;
 
       for (std::string &event_str : event_strs) {

--- a/src/entrypoint.cpp
+++ b/src/entrypoint.cpp
@@ -269,7 +269,7 @@ namespace aperf {
         return 1;
       }
 
-      cpu_set_t &cpu_set = cpu_config.get_cpu_profiler_set();
+      cpu_set_t cpu_set = cpu_config.get_cpu_profiler_set();
       sched_setaffinity(0, sizeof(cpu_set), &cpu_set);
 
       std::vector<std::unique_ptr<Profiler> > profilers;

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -1,0 +1,291 @@
+// AdaptivePerf: comprehensive profiling tool based on Linux perf
+// Copyright (C) CERN. See LICENSE for details.
+
+#include "process.hpp"
+#include <boost/algorithm/string.hpp>
+
+#ifdef BOOST_OS_UNIX
+#include <sys/wait.h>
+#endif
+
+namespace aperf {
+  Process::Process(std::vector<std::string> &command) {
+    if (command.empty()) {
+      throw Process::EmptyCommandException();
+    }
+
+    this->command = command;
+    this->stdout_redirect = false;
+    this->stderr_redirect = false;
+    this->notifiable = false;
+    this->started = false;
+    this->writable = true;
+
+#ifdef BOOST_OS_UNIX
+    this->stdout_fd = -1;
+#endif
+  }
+
+  void Process::add_env(std::string &key, std::string &value) {
+    this->env.push_back(std::make_pair(key, value));
+  }
+
+  void Process::set_redirect_stdout(fs::path &path) {
+    this->stdout_redirect = true;
+    this->stdout_path = path;
+  }
+
+  void Process::set_redirect_stdout(Process &process) {
+    this->stdout_redirect = true;
+
+#ifdef BOOST_OS_UNIX
+    this->stdout_fd = process.stdin_pipe[1];
+    process.writable = false;
+#else
+    this->stdout_redirect = false;
+    throw Process::NotImplementedException();
+#endif
+  }
+
+  void Process::set_redirect_stderr(fs::path &path) {
+    this->stderr_redirect = true;
+    this->stderr_path = path;
+  }
+
+  int Process::start(bool wait_for_notify,
+                     CPUConfig &cpu_config,
+                     fs::path working_path) {
+    if (wait_for_notify) {
+      this->notifiable = true;
+    }
+
+#ifdef BOOST_OS_UNIX
+    std::vector<std::string> env_entries;
+
+    for (int i = 0; i < this->env.size(); i++) {
+      env_entries.push_back(this->env[i].first + "=\"" +
+                            boost::replace_all_copy(this->env[i].second,
+                                                    "\"", "\\\""));
+    }
+
+    if (this->notifiable && pipe(this->notify_pipe) == -1) {
+      throw Process::StartException();
+    }
+
+    if (pipe(this->stdin_pipe) == -1) {
+      if (this->notifiable) {
+        close(this->notify_pipe[0]);
+        close(this->notify_pipe[1]);
+        this->notifiable = false;
+      }
+
+      throw Process::StartException();
+    }
+
+    pid_t forked = fork();
+
+    if (forked == 0) {
+      // This executed in a separate process with everything effectively
+      // copied (NOT shared!)
+
+      if (this->notifiable) {
+        close(this->notify_pipe[1]);
+        char buf;
+        int bytes_read = 0;
+        int received = ::read(this->notify_pipe[0], &buf, 1);
+        close(this->notify_pipe[1]);
+
+        if (received <= 0 || buf != 0x03) {
+          std::exit(Process::ERROR_START_PROFILE);
+        }
+      }
+
+      close(this->stdin_pipe[1]);
+
+      fs::current_path(working_path);
+
+      if (this->stderr_redirect) {
+        int stderr_fd = creat(this->stderr_path.c_str(),
+                              S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+
+        if (stderr_fd == -1) {
+          std::exit(Process::ERROR_STDERR);
+        }
+
+        if (dup2(stderr_fd, STDERR_FILENO) == -1) {
+          std::exit(Process::ERROR_STDERR_DUP2);
+        }
+
+        close(stderr_fd);
+      }
+
+
+      if (this->stdout_redirect) {
+        int stdout_fd;
+
+        if (this->stdout_fd == -1) {
+          stdout_fd = creat(this->stdout_path.c_str(),
+                                S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+
+          if (stdout_fd == -1) {
+            std::exit(Process::ERROR_STDOUT);
+          }
+        } else {
+          stdout_fd = this->stdout_fd;
+        }
+
+        if (dup2(stdout_fd, STDOUT_FILENO) == -1) {
+          std::exit(Process::ERROR_STDOUT_DUP2);
+        }
+
+        close(stdout_fd);
+      }
+
+      if (dup2(this->stdin_pipe[0], STDIN_FILENO) == -1) {
+        std::exit(Process::ERROR_STDIN_DUP2);
+      }
+
+      char *argv[this->command.size() + 1];
+
+      for (int i = 0; i < this->command.size(); i++) {
+        argv[i] = (char *)this->command[i].c_str();
+      }
+
+      argv[this->command.size()] = nullptr;
+
+      char *env[env_entries.size() + 1];
+
+      for (int i = 0; i < env_entries.size(); i++) {
+        env[i] = (char *)env_entries[i].c_str();
+      }
+
+      env[env_entries.size()] = nullptr;
+
+      cpu_set_t &cpu_set = cpu_config.get_cpu_command_set();
+
+      if (sched_setaffinity(0, sizeof(cpu_set), &cpu_set) == -1) {
+        std::exit(Process::ERROR_AFFINITY);
+      }
+
+      execvpe(this->command[0].c_str(), argv, env);
+
+      // This is reached only if execvpe fails
+      std::exit(errno);
+    }
+
+    if (this->notifiable) {
+      close(this->notify_pipe[0]);
+    }
+
+    if (forked == -1) {
+      if (this->notifiable) {
+        close(this->notify_pipe[1]);
+        this->notifiable = false;
+      }
+
+      throw Process::StartException();
+    }
+
+    this->started = true;
+    this->id = forked;
+    return forked;
+#else
+    this->notifiable = false;
+    throw Process::NotImplementedException();
+#endif
+  }
+
+  void Process::notify() {
+    if (this->started) {
+      if (this->notifiable) {
+#ifdef BOOST_OS_UNIX
+        char to_send = 0x03;
+        int written = 0;
+        bool all_written = false;
+        int retries = 0;
+
+        while (!all_written &&
+               (written = ::write(this->notify_pipe[1], &to_send, 1)) != -1) {
+          if (written == 0) {
+            if (retries >= 5) {
+              throw Process::WriteException();
+            }
+
+            retries++;
+          }
+
+          all_written = true;
+        }
+
+        close(this->notify_pipe[1]);
+        this->notifiable = false;
+#else
+        throw Process::NotImplementedException();
+#endif
+      } else {
+        throw Process::NotNotifiableException();
+      }
+    } else {
+      throw Process::NotStartedException();
+    }
+  }
+
+  void Process::write_stdin(char *buf, unsigned int size) {
+    if (this->started) {
+      if (this->writable) {
+#ifdef BOOST_OS_UNIX
+        int written = 0;
+        int total_written = 0;
+        int retries = 0;
+
+        while (total_written < size &&
+               (written = ::write(this->stdin_pipe[1], buf, size)) != -1) {
+          if (written == 0) {
+            if (retries >= 5) {
+              throw Process::WriteException();
+            }
+
+            retries++;
+          } else {
+            retries = 0;
+          }
+
+          total_written += written;
+        }
+
+        if (written == -1) {
+          throw Process::WriteException();
+        }
+#else
+        throw Process::NotImplementedException();
+#endif
+      } else {
+        throw Process::NotWritableException();
+      }
+    } else {
+      throw Process::NotStartedException();
+    }
+  }
+
+  int Process::join() {
+    if (this->started) {
+#ifdef BOOST_OS_UNIX
+      int status;
+      int result = waitpid(this->id, &status, 0);
+
+      if (result != this->id) {
+        throw Process::WaitException();
+      }
+
+      this->started = false;
+      this->notifiable = false;
+
+      return WEXITSTATUS(status);
+#else
+      throw Process::NotImplementedException();
+#endif
+    } else {
+      throw Process::NotStartedException();
+    }
+  }
+};

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -73,6 +73,12 @@ namespace aperf {
     }
 
     std::vector<std::string> env_entries;
+    char **cur_existing_env_entry = environ;
+
+    while (*cur_existing_env_entry != nullptr) {
+      env_entries.push_back(std::string(*cur_existing_env_entry));
+      cur_existing_env_entry++;
+    }
 
     for (int i = 0; i < this->env.size(); i++) {
       env_entries.push_back(this->env[i].first + "=" + this->env[i].second);

--- a/src/process.hpp
+++ b/src/process.hpp
@@ -1,0 +1,66 @@
+// AdaptivePerf: comprehensive profiling tool based on Linux perf
+// Copyright (C) CERN. See LICENSE for details.
+
+#ifndef PROCESS_HPP_
+#define PROCESS_HPP_
+
+#include "profiling.hpp"
+#include <vector>
+#include <string>
+#include <filesystem>
+#include <boost/predef.h>
+
+namespace aperf {
+  namespace fs = std::filesystem;
+
+  class Process {
+  private:
+    std::vector<std::string> command;
+    std::vector<std::pair<std::string, std::string> > env;
+    bool stdout_redirect;
+    fs::path stdout_path;
+    bool stderr_redirect;
+    fs::path stderr_path;
+    bool notifiable;
+    bool writable;
+#ifdef BOOST_OS_UNIX
+    int notify_pipe[2];
+    int stdin_pipe[2];
+    int stdout_fd;
+#endif
+    bool started;
+    int id;
+
+  public:
+    const int ERROR_START_PROFILE = 200;
+    const int ERROR_STDOUT = 201;
+    const int ERROR_STDERR = 202;
+    const int ERROR_STDOUT_DUP2 = 203;
+    const int ERROR_STDERR_DUP2 = 204;
+    const int ERROR_AFFINITY = 205;
+    const int ERROR_STDIN_DUP2 = 206;
+
+    Process(std::vector<std::string> &command);
+    void add_env(std::string &key, std::string &value);
+    void set_redirect_stdout(fs::path &path);
+    void set_redirect_stdout(Process &process);
+    void set_redirect_stderr(fs::path &path);
+    int start(bool wait_for_notify,
+              CPUConfig &cpu_config,
+              fs::path working_path = fs::current_path());
+    void notify();
+    void write_stdin(char *buf, unsigned int size);
+    int join();
+
+    class NotWritableException : public std::exception { };
+    class WriteException : public std::exception { };
+    class StartException : public std::exception { };
+    class EmptyCommandException : public std::exception { };
+    class WaitException : public std::exception { };
+    class NotStartedException : public std::exception { };
+    class NotNotifiableException : public std::exception { };
+    class NotImplementedException : public std::exception { };
+  };
+};
+
+#endif

--- a/src/process.hpp
+++ b/src/process.hpp
@@ -30,6 +30,7 @@ namespace aperf {
     int stdout_pipe[2];
     int *stdout_fd;
     std::unique_ptr<FileDescriptor> stdout_reader;
+    std::unique_ptr<FileDescriptor> stdin_writer;
 #endif
     bool started;
     int id;
@@ -47,12 +48,13 @@ namespace aperf {
 
     Process(std::vector<std::string> &command,
             unsigned int buf_size = 1024);
+    ~Process();
     void add_env(std::string key, std::string value);
     void set_redirect_stdout(fs::path path);
     void set_redirect_stdout(Process &process);
     void set_redirect_stderr(fs::path path);
     int start(bool wait_for_notify,
-              CPUConfig &cpu_config,
+              const CPUConfig &cpu_config,
               bool is_profiler,
               fs::path working_path = fs::current_path());
     void notify();
@@ -62,10 +64,9 @@ namespace aperf {
     bool is_running();
     void close_stdin();
 
-    class ReadException : public std::exception { };
+    class NotifyException : public std::exception { };
     class NotReadableException : public std::exception { };
     class NotWritableException : public std::exception { };
-    class WriteException : public std::exception { };
     class StartException : public std::exception { };
     class EmptyCommandException : public std::exception { };
     class WaitException : public std::exception { };

--- a/src/process.hpp
+++ b/src/process.hpp
@@ -23,35 +23,47 @@ namespace aperf {
     fs::path stderr_path;
     bool notifiable;
     bool writable;
+    unsigned int buf_size;
 #ifdef BOOST_OS_UNIX
     int notify_pipe[2];
     int stdin_pipe[2];
-    int stdout_fd;
+    int stdout_pipe[2];
+    int *stdout_fd;
+    std::unique_ptr<FileDescriptor> stdout_reader;
 #endif
     bool started;
     int id;
 
   public:
-    const int ERROR_START_PROFILE = 200;
-    const int ERROR_STDOUT = 201;
-    const int ERROR_STDERR = 202;
-    const int ERROR_STDOUT_DUP2 = 203;
-    const int ERROR_STDERR_DUP2 = 204;
-    const int ERROR_AFFINITY = 205;
-    const int ERROR_STDIN_DUP2 = 206;
+    static const int ERROR_START_PROFILE = 200;
+    static const int ERROR_STDOUT = 201;
+    static const int ERROR_STDERR = 202;
+    static const int ERROR_STDOUT_DUP2 = 203;
+    static const int ERROR_STDERR_DUP2 = 204;
+    static const int ERROR_AFFINITY = 205;
+    static const int ERROR_STDIN_DUP2 = 206;
+    static const int ERROR_NOT_FOUND = 207;
+    static const int ERROR_NO_ACCESS = 208;
 
-    Process(std::vector<std::string> &command);
-    void add_env(std::string &key, std::string &value);
-    void set_redirect_stdout(fs::path &path);
+    Process(std::vector<std::string> &command,
+            unsigned int buf_size = 1024);
+    void add_env(std::string key, std::string value);
+    void set_redirect_stdout(fs::path path);
     void set_redirect_stdout(Process &process);
-    void set_redirect_stderr(fs::path &path);
+    void set_redirect_stderr(fs::path path);
     int start(bool wait_for_notify,
               CPUConfig &cpu_config,
+              bool is_profiler,
               fs::path working_path = fs::current_path());
     void notify();
+    std::string read_line();
     void write_stdin(char *buf, unsigned int size);
     int join();
+    bool is_running();
+    void close_stdin();
 
+    class ReadException : public std::exception { };
+    class NotReadableException : public std::exception { };
     class NotWritableException : public std::exception { };
     class WriteException : public std::exception { };
     class StartException : public std::exception { };

--- a/src/profilers.cpp
+++ b/src/profilers.cpp
@@ -161,6 +161,12 @@ namespace aperf {
 
     env_script = {"APERF_SERV_CONNECT=" + instrs};
 
+    if (this->acceptor.get() != nullptr) {
+      std::string instrs = this->acceptor->get_type() + " " +
+        this->acceptor->get_connection_instructions();
+      env_script.push_back("APERF_CONNECT=" + instrs);
+    }
+
     int pipe_fd[2];
 
     if (pipe(pipe_fd) == -1) {
@@ -392,6 +398,10 @@ namespace aperf {
 
       return code;
     });
+
+    if (this->acceptor.get() != nullptr) {
+      this->connection = this->acceptor->accept(this->buf_size);
+    }
   }
 
   unsigned int Perf::get_thread_count() {

--- a/src/profilers.cpp
+++ b/src/profilers.cpp
@@ -280,7 +280,7 @@ namespace aperf {
     close(pipe_fd[0]);
     close(pipe_fd[1]);
 
-    this->process = std::async([=]() {
+    this->process = std::async([=, this]() {
       int status_record;
       int result = waitpid(forked_record, &status_record, 0);
 

--- a/src/profilers.cpp
+++ b/src/profilers.cpp
@@ -141,9 +141,8 @@ namespace aperf {
                      "--buffer-events", this->perf_event.options[2],
                      "--buffer-off-cpu-events", this->perf_event.options[3],
                      "--pid=" + std::to_string(pid)};
-      argv_script = {"perf", "script","-s", APERF_SCRIPT_PATH "/adaptiveperf-process.py",
-                     "-F", "comm,tid,pid,time,event,ip,sym,dso,period",
-                     "--ns", "--demangle", "--demangle-kernel",
+      argv_script = {"perf", "script", "-s", APERF_SCRIPT_PATH "/adaptiveperf-process.py",
+                     "--demangle", "--demangle-kernel",
                      "--max-stack=" + std::to_string(this->max_stack)};
     } else {
       stdout = result_out / ("perf_script_" + this->perf_event.name + "_stdout.log");
@@ -156,8 +155,7 @@ namespace aperf {
                      "--buffer-events", this->perf_event.options[1],
                      "--pid=" + std::to_string(pid)};
       argv_script = {"perf", "script", "-s", APERF_SCRIPT_PATH "/adaptiveperf-process.py",
-                     "-F", "comm,tid,pid,time,event,ip,sym,dso,period",
-                     "--ns", "--demangle", "--demangle-kernel",
+                     "--demangle", "--demangle-kernel",
                      "--max-stack=" + std::to_string(this->max_stack)};
     }
 

--- a/src/profilers.cpp
+++ b/src/profilers.cpp
@@ -178,6 +178,10 @@ namespace aperf {
     this->script_proc->start(false, this->cpu_config, true, result_processed);
     this->record_proc->start(false, this->cpu_config, true, result_processed);
 
+    if (this->acceptor.get() != nullptr) {
+      this->connection = this->acceptor->accept(this->buf_size);
+    }
+
     this->process = std::async([&, this]() {
       this->record_proc->close_stdin();
       int code = this->record_proc->join();
@@ -269,10 +273,6 @@ namespace aperf {
 
       return code;
     });
-
-    if (this->acceptor.get() != nullptr) {
-      this->connection = this->acceptor->accept(this->buf_size);
-    }
   }
 
   unsigned int Perf::get_thread_count() {

--- a/src/profilers.hpp
+++ b/src/profilers.hpp
@@ -5,6 +5,7 @@
 #define PROFILERS_HPP_
 
 #include "profiling.hpp"
+#include "process.hpp"
 #include "requirements.hpp"
 #include "print.hpp"
 #include "server/server.hpp"
@@ -57,6 +58,8 @@ namespace aperf {
     std::string name;
     std::vector<std::unique_ptr<Requirement> > requirements;
     int max_stack;
+    std::unique_ptr<Process> record_proc;
+    std::unique_ptr<Process> script_proc;
 
   public:
     Perf(fs::path perf_path,

--- a/src/profiling.cpp
+++ b/src/profiling.cpp
@@ -728,7 +728,7 @@ namespace aperf {
     int index = 0;
 
     for (auto &elem : dso_offsets) {
-      auto process = [index, elem, &sources, &source_files, &cpu_config]() {
+      auto process_func = [index, elem, cpu_config, &sources, &source_files]() {
         std::vector<std::string> cmd = {"addr2line", "-e", elem.first};
         Process process(cmd);
         process.start(false, cpu_config, true);
@@ -756,7 +756,7 @@ namespace aperf {
         source_files[index] = files;
       };
 
-      boost::asio::post(pool, process);
+      boost::asio::post(pool, process_func);
       index++;
     }
 

--- a/src/profiling.cpp
+++ b/src/profiling.cpp
@@ -721,7 +721,14 @@ namespace aperf {
     }
 
     nlohmann::json sources_json = nlohmann::json::object();
-    boost::asio::thread_pool pool(cpu_config.get_profiler_thread_count());
+
+    // The number of threads needs to stay at 1 here because of a bug
+    // (a race condition?) causing randomly addr2line not to terminate after
+    // the stdin pipe is closed.
+    //
+    // TODO: fix this
+    boost::asio::thread_pool pool(1);
+
     std::pair<std::string, nlohmann::json> sources[dso_offsets.size()];
     std::unordered_set<fs::path> source_files[dso_offsets.size()];
 

--- a/src/profiling.cpp
+++ b/src/profiling.cpp
@@ -81,7 +81,7 @@ namespace aperf {
      A CPUConfig object can be invalid only if the string mask used
      for its construction is invalid.
   */
-  bool CPUConfig::is_valid() {
+  bool CPUConfig::is_valid() const {
     return this->valid;
   }
 
@@ -89,7 +89,7 @@ namespace aperf {
      Returns the number of profiler threads that can be spawned
      based on how many cores are allowed for doing the profiling.
   */
-  int CPUConfig::get_profiler_thread_count() {
+  int CPUConfig::get_profiler_thread_count() const {
     return this->profiler_thread_count;
   }
 
@@ -97,7 +97,7 @@ namespace aperf {
      Returns the sched_setaffinity-compatible CPU set for doing
      the profiling.
   */
-  cpu_set_t & CPUConfig::get_cpu_profiler_set() {
+  cpu_set_t CPUConfig::get_cpu_profiler_set() const {
     return this->cpu_profiler_set;
   }
 
@@ -105,7 +105,7 @@ namespace aperf {
      Returns the sched_setaffinity-compatible CPU set for running
      the profiled command.
   */
-  cpu_set_t & CPUConfig::get_cpu_command_set() {
+  cpu_set_t CPUConfig::get_cpu_command_set() const {
     return this->cpu_command_set;
   }
 

--- a/src/profiling.hpp
+++ b/src/profiling.hpp
@@ -14,6 +14,7 @@
 #include <queue>
 #include <sched.h>
 #include <thread>
+#include "server/socket.hpp"
 
 namespace aperf {
   namespace fs = std::filesystem;
@@ -102,6 +103,11 @@ namespace aperf {
      A class describing a profiler.
   */
   class Profiler {
+  protected:
+    std::unique_ptr<Acceptor> acceptor;
+    std::unique_ptr<Connection> connection;
+    unsigned int buf_size;
+
   public:
     virtual ~Profiler() { }
 
@@ -111,7 +117,8 @@ namespace aperf {
     virtual std::string get_name() = 0;
 
     /**
-       Starts the profiler.
+       Starts the profiler (and establishes the generic message connection
+       if the acceptor is set via set_acceptor()).
 
        @param pid                 The PID of a process the profiler should
                                   be attached to. This may be left unused by
@@ -163,6 +170,31 @@ namespace aperf {
        to run.
     */
     virtual std::vector<std::unique_ptr<Requirement> > &get_requirements() = 0;
+
+    /**
+       Sets the acceptor used for establishing a connection for
+       exchanging generic messages with the profiler.
+
+       @param acceptor The acceptor to use.
+       @param buf_size The buffer size for a connection that the
+                       acceptor will accept.
+    */
+    void set_acceptor(std::unique_ptr<Acceptor> &acceptor,
+                      unsigned int buf_size) {
+      this->acceptor = std::move(acceptor);
+      this->buf_size = buf_size;
+    }
+
+    /**
+       Gets the connection used for exchanging generic messages with
+       the profiler.
+
+       WARNING: A null pointer will be returned if start() hasn't been
+       called before or the acceptor is not set via set_acceptor().
+    */
+    std::unique_ptr<Connection> &get_connection() {
+      return this->connection;
+    }
   };
 
   CPUConfig get_cpu_config(int post_processing_threads, bool external_server);

--- a/src/profiling.hpp
+++ b/src/profiling.hpp
@@ -78,10 +78,10 @@ namespace aperf {
 
   public:
     CPUConfig(std::string mask);
-    bool is_valid();
-    int get_profiler_thread_count();
-    cpu_set_t &get_cpu_profiler_set();
-    cpu_set_t &get_cpu_command_set();
+    bool is_valid() const;
+    int get_profiler_thread_count() const;
+    cpu_set_t get_cpu_profiler_set() const;
+    cpu_set_t get_cpu_command_set() const;
   };
 
   /**

--- a/src/scripts/adaptiveperf-process.py
+++ b/src/scripts/adaptiveperf-process.py
@@ -19,10 +19,9 @@ sys.path.append(os.environ['PERF_EXEC_PATH'] +
 from perf_trace_context import *
 from Core import *
 
-cur_code = [32]  # In ASCII
+cur_code_sym = [32]  # In ASCII
 
-def next_code():
-    global cur_code
+def next_code(cur_code):
     res = ''.join(map(chr, cur_code))
 
     for i in range(len(cur_code)):
@@ -41,7 +40,10 @@ def next_code():
 
 event_streams = []
 next_index = 0
-callchain_dict = defaultdict(next_code)
+symbol_dict = defaultdict(lambda: next_code(cur_code_sym))
+dso_dict = defaultdict(lambda: defaultdict(dict))
+src_files = set()
+# dso_files = set()
 overall_event_type = None
 perf_map_paths = set()
 
@@ -54,18 +56,23 @@ def get_next_event_stream():
 
 
 event_stream_dict = defaultdict(lambda: defaultdict(get_next_event_stream))
+frontend_stream = None
 
 
 def write(stream, msg):
     if isinstance(stream, socket.socket):
         stream.sendall((msg + '\n').encode('utf-8'))
     else:
-        stream.write((msg + '\n').encode('utf-8'))
+        if 'b' in stream.mode:
+            stream.write((msg + '\n').encode('utf-8'))
+        else:
+            stream.write(msg + '\n')
+
         stream.flush()
 
 
 def trace_begin():
-    global event_streams
+    global event_streams, frontend_stream
 
     serv_connect = os.environ['APERF_SERV_CONNECT'].split(' ')
     instrs = serv_connect[1:]
@@ -81,6 +88,16 @@ def trace_begin():
             stream.write('connect'.encode('ascii'))
             stream.flush()
             event_streams.append(stream)
+
+    frontend_connect = os.environ['APERF_CONNECT'].split(' ')
+    instrs = frontend_connect[1:]
+    parts = instrs[0].split('_')
+
+    if frontend_connect[0] == 'pipe':
+        stream = os.fdopen(int(parts[1]), 'w')
+        stream.write('connect')
+        stream.flush()
+        frontend_stream = stream
 
 
 def process_event(param_dict):
@@ -102,8 +119,6 @@ def process_event(param_dict):
         else:
             overall_event_type = parsed_event_type
 
-    callchain = []
-
     # Callchain symbol names are attempted to be obtained here. In case of
     # failure, an instruction address is put instead, along with
     # the name of an executable/library if available.
@@ -117,26 +132,54 @@ def process_event(param_dict):
     # map (i.e. the name of an executable/library is in form of
     # perf-<number>.map), the path to the map is saved so that AdaptivePerf
     # can copy it to the profiling results directory later.
-    for elem in raw_callchain:
-        if 'dso' in elem and \
-           re.search(r'^perf\-\d+\.map$', Path(elem['dso']).name) is not None:
-            p = Path(elem['dso'])
-            perf_map_paths.add(str(p))
-            callchain.append(f'({elem["ip"]:#x};{p.name})')
-        elif 'sym' in elem and 'name' in elem['sym']:
-            callchain.append(callchain_dict[elem['sym']['name']])
+    def process_callchain_elem(elem):
+        sym_result = [f'[{elem["ip"]:#x}]', '']
+        off_result = hex(elem['ip'])
+
+        if 'sym' in elem and 'name' in elem['sym']:
+            sym_result[0] = elem['sym']['name']
+
+            if 'dso' in elem:
+                # dso_files.add(elem['dso'])
+                sym_result[1] = elem['dso']
+                off_result = hex(elem['dso_off'])
         elif 'dso' in elem:
             p = Path(elem['dso'])
-            callchain.append(f'({elem["ip"]:#x};{p.name})')
-        else:
-            callchain.append(f'({elem["ip"]:#x})')
+            if re.search(r'^perf\-\d+\.map$', p.name) is not None:
+                perf_map_paths.add(str(p))
+                sym_result[1] = p.name
+            else:
+                # dso_files.add(elem['dso'])
+                sym_result[0] = f'[{elem["dso"]}]'
+                sym_result[1] = elem['dso']
+                off_result = hex(elem['dso_off'])
 
-    callchain.append(f'{comm}-{pid}/{tid}')
+        if 'sym_srcfile' in elem:
+            src_files.add(elem['sym_srcfile'])
 
-    write(event_stream_dict[pid][tid], json.dumps(
-        ['<SAMPLE>', parsed_event_type,
-         str(pid), str(tid),
-         timestamp, period, callchain[::-1]]))
+            src_info = {'file': elem['sym_srcfile']}
+
+            if 'sym_srcline_num' in elem:
+                src_info['line'] = elem['sym_srcline_num']
+
+            if 'dso' in elem:
+                dso_dict[elem['dso']][hex(elem['dso_off'])] = src_info
+            else:
+                dso_dict[hex(elem['ip'])] = src_info
+
+        return symbol_dict[tuple(sym_result)], off_result
+
+    callchain = list(map(process_callchain_elem, raw_callchain))[::-1]
+
+    write(event_stream_dict[pid][tid], json.dumps({
+        'type': 'sample',
+        'event_type': parsed_event_type,
+        'pid': str(pid),
+        'tid': str(tid),
+        'time': timestamp,
+        'period': period,
+        'callchain': callchain
+    }))
 
 
 def trace_end():
@@ -147,10 +190,28 @@ def trace_end():
         stream.close()
 
     if overall_event_type is not None:
-        reverse_callchain_dict = {v: k for k, v in callchain_dict.items()}
+        reverse_symbol_dict = {v: k for k, v in symbol_dict.items()}
 
         with open(f'{overall_event_type}_callchains.json', mode='w') as f:
-            f.write(json.dumps(reverse_callchain_dict) + '\n')
+            f.write(json.dumps(reverse_symbol_dict) + '\n')
 
-        with open(f'perf_map_paths_{overall_event_type}.data', mode='w') as f:
-            f.write('\n'.join(perf_map_paths) + '\n')
+        with open(f'{overall_event_type}_sources.json', mode='w') as f:
+            f.write(json.dumps(dso_dict) + '\n')
+
+        # write(frontend_stream, json.dumps({
+        #     'type': 'dso_files',
+        #     'data': list(filter(lambda x: Path(x).exists(), dso_files))
+        # }))
+
+        write(frontend_stream, json.dumps({
+            'type': 'src_files',
+            'data': list(filter(lambda x: Path(x).exists(), src_files))
+        }))
+
+        write(frontend_stream, json.dumps({
+            'type': 'symbol_maps',
+            'data': list(perf_map_paths)
+        }))
+
+    write(frontend_stream, '<STOP>')
+    frontend_stream.close()

--- a/src/scripts/adaptiveperf-process.py
+++ b/src/scripts/adaptiveperf-process.py
@@ -134,14 +134,7 @@ def process_event(param_dict):
         sym_result = [f'[{elem["ip"]:#x}]', '']
         off_result = hex(elem['ip'])
 
-        if 'sym' in elem and 'name' in elem['sym']:
-            sym_result[0] = elem['sym']['name']
-
-            if 'dso' in elem:
-                dso_dict[elem['dso']].add(hex(elem['dso_off']))
-                sym_result[1] = elem['dso']
-                off_result = hex(elem['dso_off'])
-        elif 'dso' in elem:
+        if 'dso' in elem:
             p = Path(elem['dso'])
             if re.search(r'^perf\-\d+\.map$', p.name) is not None:
                 perf_map_paths.add(str(p))
@@ -151,6 +144,9 @@ def process_event(param_dict):
                 sym_result[0] = f'[{elem["dso"]}]'
                 sym_result[1] = elem['dso']
                 off_result = hex(elem['dso_off'])
+
+        if 'sym' in elem and 'name' in elem['sym']:
+            sym_result[0] = elem['sym']['name']
 
         return symbol_dict[tuple(sym_result)], off_result
 

--- a/src/scripts/adaptiveperf-syscall-process.py
+++ b/src/scripts/adaptiveperf-syscall-process.py
@@ -17,10 +17,9 @@ from collections import defaultdict
 sys.path.append(os.environ['PERF_EXEC_PATH'] +
                 '/scripts/python/Perf-Trace-Util/lib/Perf/Trace')
 
-cur_code = [32]  # In ASCII
+cur_code_sym = [32]  # In ASCII
 
-def next_code():
-    global cur_code
+def next_code(cur_code):
     res = ''.join(map(chr, cur_code))
 
     for i in range(len(cur_code)):
@@ -38,22 +37,29 @@ def next_code():
 
 
 event_stream = None
+frontend_stream = None
 tid_dict = {}
-callchain_dict = defaultdict(next_code)
+symbol_dict = defaultdict(lambda: next_code(cur_code_sym))
+dso_dict = defaultdict(lambda: defaultdict(dict))
+src_files = set()
+# dso_files = set()
 perf_map_paths = set()
 
-def write(msg):
-    global event_stream
 
-    if isinstance(event_stream, socket.socket):
-        event_stream.sendall((msg + '\n').encode('utf-8'))
+def write(stream, msg):
+    if isinstance(stream, socket.socket):
+        stream.sendall((msg + '\n').encode('utf-8'))
     else:
-        event_stream.write((msg + '\n').encode('utf-8'))
-        event_stream.flush()
+        if 'b' in stream.mode:
+            stream.write((msg + '\n').encode('utf-8'))
+        else:
+            stream.write(msg + '\n')
+
+        stream.flush()
 
 
 def syscall_callback(stack, ret_value):
-    global perf_map_paths
+    global perf_map_paths, dso_dict, src_files
 
     if int(ret_value) == 0:
         return
@@ -72,38 +78,66 @@ def syscall_callback(stack, ret_value):
     # perf-<number>.map), the path to the map is saved so that AdaptivePerf
     # can copy it to the profiling results directory later.
     def process_callchain_elem(elem):
-        if 'dso' in elem and \
-           re.search(r'^perf\-\d+\.map$', Path(elem['dso']).name) is not None:
-            p = Path(elem['dso'])
-            perf_map_paths.add(str(p))
-            return f'({elem["ip"]:#x};{p.name})'
-        elif 'sym' in elem and 'name' in elem['sym']:
-            return callchain_dict[elem['sym']['name']]
+        sym_result = [f'[{elem["ip"]:#x}]', '']
+        off_result = hex(elem['ip'])
+
+        if 'sym' in elem and 'name' in elem['sym']:
+            sym_result[0] = elem['sym']['name']
+
+            if 'dso' in elem:
+                # dso_files.add(elem['dso'])
+                sym_result[1] = elem['dso']
+                off_result = hex(elem['dso_off'])
         elif 'dso' in elem:
             p = Path(elem['dso'])
-            return f'({elem["ip"]:#x};{p.name})'
-        else:
-            return f'({elem["ip"]:#x})'
+            if re.search(r'^perf\-\d+\.map$', p.name) is not None:
+                perf_map_paths.add(str(p))
+                sym_result[1] = p.name
+            else:
+                # dso_files.add(elem['dso'])
+                sym_result[0] = f'[{elem["dso"]}]'
+                sym_result[1] = elem['dso']
+                off_result = hex(elem['dso_off'])
 
-    write(json.dumps([
-        '<SYSCALL>', str(ret_value), list(map(process_callchain_elem, stack))
-    ]))
+        if 'sym_srcfile' in elem:
+            src_files.add(elem['sym_srcfile'])
+
+            src_info = {'file': elem['sym_srcfile']}
+
+            if 'sym_srcline_num' in elem:
+                src_info['line'] = elem['sym_srcline_num']
+
+            if 'dso' in elem:
+                dso_dict[elem['dso']][hex(elem['dso_off'])] = src_info
+            else:
+                dso_dict[hex(elem['ip'])] = src_info
+
+        return symbol_dict[tuple(sym_result)], off_result
+
+    callchain = list(map(process_callchain_elem, stack))[::-1]
+
+    write(event_stream, json.dumps({
+        'type': 'syscall',
+        'ret_value': str(ret_value),
+        'callchain': callchain
+    }))
 
 
 def syscall_tree_callback(syscall_type, comm_name, pid, tid, time,
                           ret_value):
-    write(json.dumps([
-        '<SYSCALL_TREE>',
-        syscall_type,
-        comm_name,
-        str(pid),
-        str(tid),
-        time,
-        str(ret_value)]))
+    write(event_stream, json.dumps({
+        'type': 'syscall_meta',
+        'subtype': syscall_type,
+        'comm': comm_name,
+        'pid': str(pid),
+        'tid': str(tid),
+        'time': time,
+        'ret_value': str(ret_value)
+    }))
 
 
 def trace_begin():
-    global event_stream
+    global event_stream, frontend_stream
 
     serv_connect = os.environ['APERF_SERV_CONNECT'].split(' ')
     parts = serv_connect[1].split('_')
@@ -117,20 +151,48 @@ def trace_begin():
         event_stream.write('connect'.encode('ascii'))
         event_stream.flush()
 
+    frontend_connect = os.environ['APERF_CONNECT'].split(' ')
+    instrs = frontend_connect[1:]
+    parts = instrs[0].split('_')
+
+    if frontend_connect[0] == 'pipe':
+        stream = os.fdopen(int(parts[1]), 'w')
+        stream.write('connect')
+        stream.flush()
+        frontend_stream = stream
+
 
 def trace_end():
     global event_stream, callchain_dict, perf_map_paths
 
-    write('<STOP>')
+    write(event_stream, '<STOP>')
     event_stream.close()
 
-    reverse_callchain_dict = {v: k for k, v in callchain_dict.items()}
+    reverse_symbol_dict = {v: k for k, v in symbol_dict.items()}
 
     with open('syscall_callchains.json', mode='w') as f:
-        f.write(json.dumps(reverse_callchain_dict) + '\n')
+        f.write(json.dumps(reverse_symbol_dict) + '\n')
 
-    with open('perf_map_paths_syscalls.data', mode='w') as f:
-        f.write('\n'.join(perf_map_paths) + '\n')
+    with open('syscall_sources.json', mode='w') as f:
+        f.write(json.dumps(dso_dict) + '\n')
+
+    # write(frontend_stream, json.dumps({
+    #     'type': 'dso_files',
+    #     'data': list(filter(lambda x: Path(x).exists(), dso_files))
+    # }))
+
+    write(frontend_stream, json.dumps({
+        'type': 'src_files',
+        'data': list(filter(lambda x: Path(x).exists(), src_files))
+    }))
+
+    write(frontend_stream, json.dumps({
+        'type': 'symbol_maps',
+        'data': list(perf_map_paths)
+    }))
+
+    write(frontend_stream, '<STOP>')
+    frontend_stream.close()
 
 
 def sched__sched_process_fork(event_name, context, common_cpu,

--- a/src/scripts/adaptiveperf-syscall-process.py
+++ b/src/scripts/adaptiveperf-syscall-process.py
@@ -79,14 +79,7 @@ def syscall_callback(stack, ret_value):
         sym_result = [f'[{elem["ip"]:#x}]', '']
         off_result = hex(elem['ip'])
 
-        if 'sym' in elem and 'name' in elem['sym']:
-            sym_result[0] = elem['sym']['name']
-
-            if 'dso' in elem:
-                dso_dict[elem['dso']].add(hex(elem['dso_off']))
-                sym_result[1] = elem['dso']
-                off_result = hex(elem['dso_off'])
-        elif 'dso' in elem:
+        if 'dso' in elem:
             p = Path(elem['dso'])
             if re.search(r'^perf\-\d+\.map$', p.name) is not None:
                 perf_map_paths.add(str(p))
@@ -96,6 +89,9 @@ def syscall_callback(stack, ret_value):
                 sym_result[0] = f'[{elem["dso"]}]'
                 sym_result[1] = elem['dso']
                 off_result = hex(elem['dso_off'])
+
+        if 'sym' in elem and 'name' in elem['sym']:
+            sym_result[0] = elem['sym']['name']
 
         return symbol_dict[tuple(sym_result)], off_result
 

--- a/src/server/client.cpp
+++ b/src/server/client.cpp
@@ -97,7 +97,7 @@ namespace aperf {
         threads[i].get();
         nlohmann::json &thread_result = subclients[i]->get_result();
         for (auto &elem : thread_result.items()) {
-          if (elem.key() == "<SYSCALL_TREE>") {
+          if (elem.key() == "syscall_meta") {
             start_time = elem.value()[0];
 
             for (auto &tid : elem.value()[1]) {
@@ -109,7 +109,7 @@ namespace aperf {
 
               tids.insert(tid_str);
             }
-          } else if (elem.key() == "<SYSCALL>") {
+          } else if (elem.key() == "syscall") {
             for (auto &elem2 : elem.value().items()) {
               metadata["callchains"][elem2.key()].swap(elem2.value());
             }
@@ -117,7 +117,7 @@ namespace aperf {
         }
 
         for (auto &elem : thread_result.items()) {
-          if (elem.key().rfind("<SAMPLE>", 0) == 0) {
+          if (elem.key().rfind("sample", 0) == 0) {
             for (auto &elem2 : elem.value().items()) {
               if (elem2.value()["first_time"] >= start_time) {
                 std::regex pid_tid_regex("^(\\d+)_(\\d+)$");

--- a/src/server/server.hpp
+++ b/src/server/server.hpp
@@ -200,7 +200,7 @@ namespace aperf {
                  std::string profiled_filename,
                  unsigned int buf_size);
     void recurse(nlohmann::json &cur_elem,
-                 std::vector<std::string> &callchain_parts,
+                 std::vector<std::pair<std::string, std::string> > &callchain_parts,
                  int callchain_index,
                  unsigned long long period,
                  bool time_ordered, bool offcpu);

--- a/src/server/socket.cpp
+++ b/src/server/socket.cpp
@@ -240,7 +240,23 @@ namespace aperf {
     }
   }
 
-#ifndef SERVER_ONLY
+  void TCPSocket::write(unsigned int len, char *buf) {
+    try {
+      int bytes_written = this->socket.sendBytes(buf, len);
+      if (bytes_written != len) {
+        std::runtime_error err("Wrote " +
+                               std::to_string(bytes_written) +
+                               " bytes instead of " +
+                               std::to_string(len) +
+                               " to " +
+                               this->socket.address().toString());
+        throw ConnectionException(err);
+      }
+    } catch (net::NetException &e) {
+      throw ConnectionException(e);
+    }
+  }
+
   /**
      Constructs a FileDescriptor object.
 
@@ -416,6 +432,20 @@ namespace aperf {
     }
   }
 
+  void FileDescriptor::write(unsigned int len, char *buf) {
+    int bytes_written = ::write(this->write_fd[1], buf, len);
+
+    if (bytes_written != len) {
+      std::runtime_error err("Wrote " +
+                             std::to_string(bytes_written) +
+                             " bytes instead of " +
+                             std::to_string(len) +
+                             " to fd " +
+                             std::to_string(this->write_fd[1]));
+      throw ConnectionException(err);
+    }
+  }
+
   unsigned int FileDescriptor::get_buf_size() {
     return this->buf_size;
   }
@@ -482,5 +512,4 @@ namespace aperf {
   std::string PipeAcceptor::get_type() {
     return "pipe";
   }
-#endif
 }

--- a/src/server/socket.cpp
+++ b/src/server/socket.cpp
@@ -271,9 +271,11 @@ namespace aperf {
      Constructs a FileDescriptor object.
 
      @param read_fd  The pair of file descriptors for read()
-                     as returned by the pipe system call.
+                     as returned by the pipe system call. Can
+                     be nullptr.
      @param write_fd The pair of file descriptors for write()
-                     as returned by the pipe system call.
+                     as returned by the pipe system call. Can
+                     be nullptr.
      @param buf_size The buffer size for communication, in bytes.
   */
   FileDescriptor::FileDescriptor(int read_fd[2], int write_fd[2],
@@ -281,10 +283,22 @@ namespace aperf {
     this->buf.reset(new char[buf_size]);
     this->buf_size = buf_size;
     this->start_pos = 0;
-    this->read_fd[0] = read_fd[0];
-    this->read_fd[1] = read_fd[1];
-    this->write_fd[0] = write_fd[0];
-    this->write_fd[1] = write_fd[1];
+
+    if (read_fd != nullptr) {
+      this->read_fd[0] = read_fd[0];
+      this->read_fd[1] = read_fd[1];
+    } else {
+      this->read_fd[0] = -1;
+      this->read_fd[1] = -1;
+    }
+
+    if (write_fd != nullptr) {
+      this->write_fd[0] = write_fd[0];
+      this->write_fd[1] = write_fd[1];
+    } else {
+      this->write_fd[0] = -1;
+      this->write_fd[1] = -1;
+    }
   }
 
   FileDescriptor::~FileDescriptor() {
@@ -292,8 +306,13 @@ namespace aperf {
   }
 
   void FileDescriptor::close() {
-    ::close(this->read_fd[0]);
-    ::close(this->write_fd[1]);
+    if (this->read_fd[0] != -1) {
+      ::close(this->read_fd[0]);
+    }
+
+    if (this->write_fd[1] != -1) {
+      ::close(this->write_fd[1]);
+    }
   }
 
   int FileDescriptor::read(char *buf, unsigned int len, long timeout_seconds) {

--- a/src/server/socket.cpp
+++ b/src/server/socket.cpp
@@ -308,10 +308,12 @@ namespace aperf {
   void FileDescriptor::close() {
     if (this->read_fd[0] != -1) {
       ::close(this->read_fd[0]);
+      this->read_fd[0] = -1;
     }
 
     if (this->write_fd[1] != -1) {
       ::close(this->write_fd[1]);
+      this->write_fd[1] = -1;
     }
   }
 

--- a/src/server/socket.cpp
+++ b/src/server/socket.cpp
@@ -224,7 +224,17 @@ namespace aperf {
 
       const char *buf = msg.c_str();
 
-      this->socket.sendBytes(buf, msg.size());
+      int bytes_written = this->socket.sendBytes(buf, msg.size());
+
+      if (bytes_written != msg.size()) {
+        std::runtime_error err("Wrote " +
+                               std::to_string(bytes_written) +
+                               " bytes instead of " +
+                               std::to_string(msg.size()) +
+                               " to " +
+                               this->socket.address().toString());
+        throw ConnectionException(err);
+      }
     } catch (net::NetException &e) {
       throw ConnectionException(e);
     }

--- a/src/server/socket.hpp
+++ b/src/server/socket.hpp
@@ -109,6 +109,16 @@ namespace aperf {
     virtual void write(fs::path file) = 0;
 
     /**
+       Writes data to the connection.
+
+       @param len The number of bytes to be sent.
+       @param buf A buffer storing data to be written. Its size
+                  must be equal to or greater than the number of
+                  bytes to be sent.
+    */
+    virtual void write(unsigned int len, char *buf) = 0;
+
+    /**
        Gets the buffer size for communication, in bytes.
     */
     virtual unsigned int get_buf_size() = 0;
@@ -139,6 +149,7 @@ namespace aperf {
     virtual std::string read(long timeout_seconds = NO_TIMEOUT) = 0;
     virtual void write(std::string msg, bool new_line = true) = 0;
     virtual void write(fs::path file) = 0;
+    virtual void write(unsigned int len, char *buf) = 0;
   };
 
   /**
@@ -263,6 +274,7 @@ namespace aperf {
     std::string read(long timeout_seconds = NO_TIMEOUT);
     void write(std::string msg, bool new_line);
     void write(fs::path file);
+    void write(unsigned int len, char *buf);
   };
 
   /**
@@ -326,7 +338,6 @@ namespace aperf {
     std::string get_type();
   };
 
-#ifndef SERVER_ONLY
   /**
      A class describing a file-descriptor-based connection.
   */
@@ -351,6 +362,7 @@ namespace aperf {
     std::string read(long timeout_seconds = NO_TIMEOUT);
     void write(std::string msg, bool new_line);
     void write(fs::path file);
+    void write(unsigned int len, char *buf);
     unsigned int get_buf_size();
   };
 
@@ -397,7 +409,6 @@ namespace aperf {
     std::string get_connection_instructions();
     std::string get_type();
   };
-#endif
 }
 
 #endif

--- a/src/server/socket.hpp
+++ b/src/server/socket.hpp
@@ -350,9 +350,6 @@ namespace aperf {
     std::unique_ptr<char> buf;
     int start_pos;
 
-  protected:
-    void close();
-
   public:
     FileDescriptor(int read_fd[2],
                    int write_fd[2],
@@ -364,6 +361,7 @@ namespace aperf {
     void write(fs::path file);
     void write(unsigned int len, char *buf);
     unsigned int get_buf_size();
+    void close();
   };
 
   /**


### PR DESCRIPTION
This PR makes AdaptivePerf record specific line numbers corresponding to sampled on-CPU/off-CPU activity and new thread/process spawning. It also makes the tool automatically transfer available source code files to a profiling result destination.

**There's a bug in addr2line processing which forces it to be single-threaded only. This will be fixed hopefully soon!**

The Doxygen documentation update will follow later, the version before this PR is still valid for most cases.