### PR TITLE
Fix dependency setup in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,19 +63,16 @@ add_library(server_entrypoint.o OBJECT src/server/entrypoint.cpp)
 target_include_directories(server_entrypoint.o PRIVATE ${CMAKE_SOURCE_DIR}/src/cmd)
 
 add_library(aperfserv SHARED)
-target_include_directories(aperfserv PRIVATE ${nlohmann_json_INCLUDE_DIRS})
-target_include_directories(aperfserv PRIVATE ${Poco_INCLUDE_DIRS})
-target_link_libraries(aperfserv PRIVATE nlohmann_json::nlohmann_json)
-target_link_libraries(aperfserv PRIVATE Poco::Foundation Poco::Net)
+target_link_libraries(aperfserv PUBLIC nlohmann_json::nlohmann_json)
+target_link_libraries(aperfserv PUBLIC Poco::Foundation Poco::Net)
 target_link_libraries(aperfserv PRIVATE server.o client.o subclient.o socket.o)
 
 add_executable(adaptiveperf-server
   src/main.cpp)
 
 target_compile_definitions(adaptiveperf-server PRIVATE SERVER_ONLY)
-target_include_directories(adaptiveperf-server PRIVATE ${CLI11_INCLUDE_DIRS})
-target_link_libraries(adaptiveperf-server PRIVATE Poco::Foundation Poco::Net)
-target_link_libraries(adaptiveperf-server PRIVATE CLI11::CLI11)
+target_link_libraries(adaptiveperf-server PUBLIC Poco::Foundation Poco::Net)
+target_link_libraries(adaptiveperf-server PUBLIC CLI11::CLI11)
 target_link_libraries(adaptiveperf-server PRIVATE aperfserv server_entrypoint.o version.o)
 
 if(NOT SERVER_ONLY)
@@ -103,17 +100,11 @@ if(NOT SERVER_ONLY)
 
   find_package(LibArchive REQUIRED)
 
-  target_link_libraries(adaptiveperf PRIVATE nlohmann_json::nlohmann_json)
-  target_link_libraries(adaptiveperf PRIVATE Poco::Foundation Poco::Net)
-  target_link_libraries(adaptiveperf PRIVATE CLI11::CLI11)
-  target_link_libraries(adaptiveperf PRIVATE Boost::program_options)
-  target_link_libraries(adaptiveperf PRIVATE LibArchive::LibArchive)
-
-  target_include_directories(adaptiveperf PRIVATE ${nlohmann_json_INCLUDE_DIRS})
-  target_include_directories(adaptiveperf PRIVATE ${Poco_INCLUDE_DIRS})
-  target_include_directories(adaptiveperf PRIVATE ${CLI11_INCLUDE_DIRS})
-  target_include_directories(adaptiveperf PRIVATE ${Boost_INCLUDE_DIRS})
-  target_include_directories(adaptiveperf PRIVATE ${LibArchive_INCLUDE_DIRS})
+  target_link_libraries(adaptiveperf PUBLIC nlohmann_json::nlohmann_json)
+  target_link_libraries(adaptiveperf PUBLIC Poco::Foundation Poco::Net)
+  target_link_libraries(adaptiveperf PUBLIC CLI11::CLI11)
+  target_link_libraries(adaptiveperf PUBLIC Boost::program_options)
+  target_link_libraries(adaptiveperf PUBLIC LibArchive::LibArchive)
 
   find_library(LIBNUMA
     NAMES numa
@@ -142,8 +133,7 @@ if(NOT SERVER_ONLY)
 
   if(LIBNUMA_AVAILABLE)
     target_compile_definitions(requirements.o PRIVATE LIBNUMA_AVAILABLE)
-    target_include_directories(requirements.o PRIVATE ${LIBNUMA_INCLUDE})
-    target_link_libraries(adaptiveperf PRIVATE numa)
+    target_link_libraries(adaptiveperf PUBLIC numa)
   endif()
 
   target_link_libraries(adaptiveperf PRIVATE aperfserv)
@@ -175,15 +165,17 @@ if (ENABLE_TESTS)
   target_include_directories(auto-test-subclient PRIVATE ${CMAKE_SOURCE_DIR}/src/server)
   target_include_directories(auto-test-socket PRIVATE ${CMAKE_SOURCE_DIR}/src/server)
 
-  target_include_directories(auto-test-server PRIVATE ${Poco_INCLUDE_DIRS})
-  target_include_directories(auto-test-client PRIVATE ${Poco_INCLUDE_DIRS})
-  target_include_directories(auto-test-subclient PRIVATE ${Poco_INCLUDE_DIRS})
-  target_include_directories(auto-test-socket PRIVATE ${Poco_INCLUDE_DIRS})
+  target_link_libraries(auto-test-server PUBLIC GTest::gtest_main GTest::gmock_main Poco::Foundation Poco::Net)
+  target_link_libraries(auto-test-server PRIVATE server.o client.o)
 
-  target_link_libraries(auto-test-server PRIVATE GTest::gtest_main GTest::gmock_main Poco::Foundation Poco::Net server.o client.o)
-  target_link_libraries(auto-test-client PRIVATE GTest::gtest_main GTest::gmock_main Poco::Foundation Poco::Net client.o)
-  target_link_libraries(auto-test-subclient PRIVATE GTest::gtest_main GTest::gmock_main Poco::Foundation Poco::Net subclient.o)
-  target_link_libraries(auto-test-socket PRIVATE GTest::gtest_main GTest::gmock_main Poco::Foundation Poco::Net socket.o)
+  target_link_libraries(auto-test-client PUBLIC GTest::gtest_main GTest::gmock_main Poco::Foundation Poco::Net)
+  target_link_libraries(auto-test-client PRIVATE client.o)
+
+  target_link_libraries(auto-test-subclient PUBLIC GTest::gtest_main GTest::gmock_main Poco::Foundation Poco::Net)
+  target_link_libraries(auto-test-subclient PRIVATE subclient.o)
+
+  target_link_libraries(auto-test-socket PUBLIC GTest::gtest_main GTest::gmock_main Poco::Foundation Poco::Net)
+  target_link_libraries(auto-test-socket PRIVATE socket.o)
 
   include(GoogleTest)
   gtest_discover_tests(auto-test-server)


### PR DESCRIPTION
CMake configures building AdaptivePerf completely wrongly if any dependencies are not installed system-wide or have a custom path not known by the compiler by default. This PR fixes this.