### PR TITLE
Fix numa.h setup in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,7 @@ if(NOT SERVER_ONLY)
 
   if(LIBNUMA_AVAILABLE)
     target_compile_definitions(requirements.o PRIVATE LIBNUMA_AVAILABLE)
+    target_include_directories(requirements.o PRIVATE ${LIBNUMA_INCLUDE})
     target_link_libraries(adaptiveperf PUBLIC numa)
   endif()
 


### PR DESCRIPTION
PR #35 didn't account for the non-CMake-based setup of building AdaptivePerf with libnuma support, making CMake potentially not add the necessary include path for numa.h. This PR fixes this.