### PR TITLE
Introduce AlmaLinux-9-based container images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,7 +42,7 @@ pages:
       - public
 
 # Based on https://gitlab.cern.ch/gitlabci-examples/build_docker_image/-/blob/master/.gitlab-ci.yml
-make-docker-image:
+make-gentoo-docker-image:
   image:
     name: gcr.io/kaniko-project/executor:debug
     entrypoint: [""]
@@ -60,6 +60,28 @@ make-docker-image:
     - echo "{\"auths\":{\"$CI_REGISTRY\":{\"username\":\"$CI_DEPLOY_USER\",\"password\":\"$CI_DEPLOY_PASSWORD\"}}}" > /kaniko/.docker/config.json
     # Build and push the image from the Dockerfile at the root of the project.
     - /kaniko/executor --context $CI_PROJECT_DIR --dockerfile $CI_PROJECT_DIR/Dockerfile --destination $IMAGE_DESTINATION --destination $IMAGE_DESTINATION_NAMED --build-arg "JOBS=12"
+    # Print the full registry path of the pushed image
+    - echo "Image pushed successfully to ${IMAGE_DESTINATION} and ${IMAGE_DESTINATION_NAMED}"
+
+# Based on https://gitlab.cern.ch/gitlabci-examples/build_docker_image/-/blob/master/.gitlab-ci.yml
+make-alma9-docker-image:
+  image:
+    name: gcr.io/kaniko-project/executor:debug
+    entrypoint: [""]
+  stage: container-image-build
+  needs: []
+  script:
+    - |
+      if [[ $CI_COMMIT_BRANCH == "main" ]]; then
+        export IMAGE_DESTINATION_NAMED=$CI_REGISTRY/adaptyst/adaptyst:alma9-latest
+      else
+        export IMAGE_DESTINATION_NAMED=$CI_REGISTRY/adaptyst/adaptyst:alma9-branch-$CI_COMMIT_BRANCH
+      fi
+      export IMAGE_DESTINATION=$CI_REGISTRY/adaptyst/adaptyst:alma9-commit-$CI_COMMIT_SHORT_SHA
+    # Prepare Kaniko configuration file
+    - echo "{\"auths\":{\"$CI_REGISTRY\":{\"username\":\"$CI_DEPLOY_USER\",\"password\":\"$CI_DEPLOY_PASSWORD\"}}}" > /kaniko/.docker/config.json
+    # Build and push the image from the Dockerfile at the root of the project.
+    - /kaniko/executor --context $CI_PROJECT_DIR --dockerfile $CI_PROJECT_DIR/Dockerfile-alma9 --destination $IMAGE_DESTINATION --destination $IMAGE_DESTINATION_NAMED
     # Print the full registry path of the pushed image
     - echo "Image pushed successfully to ${IMAGE_DESTINATION} and ${IMAGE_DESTINATION_NAMED}"
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -85,7 +85,7 @@ make-alma9-docker-image:
     # Print the full registry path of the pushed image
     - echo "Image pushed successfully to ${IMAGE_DESTINATION} and ${IMAGE_DESTINATION_NAMED}"
 
-make-apptainer-image:
+make-apptainer-images:
   tags:
     - gentoo
   stage: container-image-build
@@ -95,16 +95,21 @@ make-apptainer-image:
     - echo $CI_DEPLOY_PASSWORD | sudo apptainer registry login --username $CI_DEPLOY_USER --password-stdin docker://$CI_REGISTRY
   script:
     - sudo apptainer build --build-arg project_dir="$CI_PROJECT_DIR" --build-arg registry="$CI_REGISTRY" adaptyst.sif $CI_PROJECT_DIR/apptainer.def
+    - sudo apptainer build --build-arg project_dir="$CI_PROJECT_DIR" --build-arg registry="$CI_REGISTRY" adaptyst-alma9.sif $CI_PROJECT_DIR/apptainer-alma9.def
     - |
       if [[ $CI_COMMIT_BRANCH == "main" ]]; then
         xrdfs root://eosuser.cern.ch mv $WEB_STORAGE/apptainer/adaptyst-latest.sif $WEB_STORAGE/apptainer/backup-adaptyst-latest.sif || true
+        xrdfs root://eosuser.cern.ch mv $WEB_STORAGE/apptainer/adaptyst-alma9-latest.sif $WEB_STORAGE/apptainer/backup-adaptyst-alma9-latest.sif || true
         xrdcp -C auto --rm-bad-cksum -t 5 adaptyst.sif root://eosuser.cern.ch/$WEB_STORAGE/apptainer/adaptyst-latest.sif
+        xrdcp -C auto --rm-bad-cksum -t 5 adaptyst-alma9.sif root://eosuser.cern.ch/$WEB_STORAGE/apptainer/adaptyst-alma9-latest.sif
       else
         xrdfs root://eosuser.cern.ch mv $WEB_STORAGE/apptainer/adaptyst-$CI_COMMIT_BRANCH.sif $WEB_STORAGE/apptainer/backup-adaptyst-$CI_COMMIT_BRANCH.sif || true
+        xrdfs root://eosuser.cern.ch mv $WEB_STORAGE/apptainer/adaptyst-alma9-$CI_COMMIT_BRANCH.sif $WEB_STORAGE/apptainer/backup-adaptyst-alma9-$CI_COMMIT_BRANCH.sif || true
         xrdcp -C auto --rm-bad-cksum -t 5 adaptyst.sif root://eosuser.cern.ch/$WEB_STORAGE/apptainer/adaptyst-$CI_COMMIT_BRANCH.sif
+        xrdcp -C auto --rm-bad-cksum -t 5 adaptyst-alma9.sif root://eosuser.cern.ch/$WEB_STORAGE/apptainer/adaptyst-alma9-$CI_COMMIT_BRANCH.sif
       fi
   after_script:
-    - rm -f adaptyst.sif
+    - rm -f adaptyst.sif adaptyst-alma9.sif
     - kdestroy -A
     - sudo apptainer registry logout docker://$CI_REGISTRY
 

--- a/Dockerfile-alma9
+++ b/Dockerfile-alma9
@@ -1,6 +1,6 @@
 FROM gitlab-registry.cern.ch/adaptyst/alma9-fp
 RUN mkdir -p /root/adaptyst
 COPY . /root/adaptyst/
-RUN dnf install -y git cmake numactl-devel cli11-devel json-devel poco-devel boost-devel libarchive-devel clang libtraceevent-devel flex bison elfutils-libelf-devel ninja-build && cd /root/adaptyst && ./build.sh -G Ninja && { echo | ./install.sh /usr } && cd .. && rm -rf adaptyst && dnf remove -y clang ninja-build
+RUN dnf install -y git cmake numactl-devel cli11-devel json-devel poco-devel boost-devel libarchive-devel clang libtraceevent-devel flex bison elfutils-libelf-devel ninja-build && cd /root/adaptyst && ./build.sh -G Ninja && { echo | ./install.sh /usr; } && cd .. && rm -rf adaptyst && dnf remove -y clang ninja-build
 RUN setcap cap_perfmon,cap_bpf+ep /opt/adaptyst/perf/bin/perf && useradd -m alma9-adaptyst
 USER alma9-adaptyst

--- a/Dockerfile-alma9
+++ b/Dockerfile-alma9
@@ -1,0 +1,6 @@
+FROM gitlab-registry.cern.ch/adaptyst/alma9-fp
+RUN mkdir -p /root/adaptyst
+COPY . /root/adaptyst/
+RUN dnf install -y git cmake numactl-devel cli11-devel json-devel poco-devel boost-devel libarchive-devel clang libtraceevent-devel flex bison elfutils-libelf-devel ninja-build && cd /root/adaptyst && ./build.sh -G Ninja && { echo | ./install.sh /usr } && cd .. && rm -rf adaptyst && dnf remove -y clang ninja-build
+RUN setcap cap_perfmon,cap_bpf+ep /opt/adaptyst/perf/bin/perf && useradd -m alma9-adaptyst
+USER alma9-adaptyst

--- a/apptainer-alma9.def
+++ b/apptainer-alma9.def
@@ -1,0 +1,13 @@
+Bootstrap: docker
+From: {{ registry }}/adaptyst/alma9-fp:latest
+
+%files
+    {{ project_dir }} adaptyst
+
+%post
+    dnf install -y git cmake numactl-devel cli11-devel json-devel poco-devel boost-devel libarchive-devel clang libtraceevent-devel flex bison elfutils-libelf-devel ninja-build
+    cd adaptyst
+    ./build.sh -G Ninja
+    echo | ./install.sh /usr
+    dnf remove -y clang ninja-build
+    cd .. && rm -rf adaptyst


### PR DESCRIPTION
This PR adds AlmaLinux-9-based Docker and Apptainer images, where glibc, GCC (including libstdc++ and libgcc), and Python 3 are compiled with frame pointers and debug information + sources.