### PR TITLE
Remove /sys/kernel/debug requirement

### DIFF
--- a/src/profilers.cpp
+++ b/src/profilers.cpp
@@ -95,7 +95,6 @@ namespace adaptyst {
     this->name = name;
     this->max_stack = 1024;
 
-    this->requirements.push_back(std::make_unique<SysKernelDebugReq>());
     this->requirements.push_back(std::make_unique<PerfEventKernelSettingsReq>(this->max_stack));
     this->requirements.push_back(std::make_unique<NUMAMitigationReq>());
   }

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -12,35 +12,6 @@
 #endif
 
 namespace adaptyst {
-  std::string SysKernelDebugReq::get_name() {
-    return "Presence of mounted /sys/kernel/debug";
-  }
-
-  bool SysKernelDebugReq::check_internal() {
-    std::ifstream mounts("/proc/mounts");
-
-    if (!mounts) {
-      print("Could not open /proc/mounts for checking "
-            "if /sys/kernel/debug is mounted!", true, true);
-      return false;
-    }
-
-    std::string element;
-
-    while (mounts) {
-      mounts >> element;
-
-      if (element == "/sys/kernel/debug") {
-        return true;
-      }
-    }
-
-    print("/sys/kernel/debug is not mounted, please mount it first by "
-          "running \"mount -t debugfs none /sys/kernel/debug\".",
-          true, true);
-    return false;
-  }
-
   /**
      Constructs a PerfEventKernelSettingsReq object.
 

--- a/src/requirements.hpp
+++ b/src/requirements.hpp
@@ -8,18 +8,6 @@
 
 namespace adaptyst {
   /**
-     A class describing the requirement of /sys/kernel/debug
-     being mounted.
-  */
-  class SysKernelDebugReq : public Requirement {
-  protected:
-    bool check_internal();
-
-  public:
-    std::string get_name();
-  };
-
-  /**
      A class describing the requirement of the correct
      "perf"-specific kernel settings.
 


### PR DESCRIPTION
The requirement of having /sys/kernel/debug mounted in a machine with a profiled program is redundant and therefore creates an unnecessary obstacle in adopting Adaptyst in more security-aware environments.

This PR removes the requirement completely.