### PR TITLE
Remove kernel.perf_event_paranoid requirement

### DIFF
--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -25,27 +25,6 @@ namespace adaptyst {
   }
 
   bool PerfEventKernelSettingsReq::check_internal() {
-    // kernel.perf_event_paranoid
-    std::ifstream paranoid("/proc/sys/kernel/perf_event_paranoid");
-
-    if (!paranoid) {
-      print("Could not check the value of kernel.perf_event_paranoid!",
-            true, true);
-      return false;
-    }
-
-    int paranoid_value;
-    paranoid >> paranoid_value;
-
-    paranoid.close();
-
-    if (paranoid_value != -1) {
-      print("kernel.perf_event_paranoid is not -1. Please run "
-            "\"sysctl kernel.perf_event_paranoid=-1\" before profiling.",
-            true, true);
-      return false;
-    }
-
     // kernel.perf_event_max_stack
     std::ifstream max_stack("/proc/sys/kernel/perf_event_max_stack");
 

--- a/src/requirements.hpp
+++ b/src/requirements.hpp
@@ -11,8 +11,7 @@ namespace adaptyst {
      A class describing the requirement of the correct
      "perf"-specific kernel settings.
 
-     These settings are kernel.perf_event_max_stack and
-     kernel.perf_event_paranoid.
+     At the moment, this is only kernel.perf_event_max_stack.
   */
   class PerfEventKernelSettingsReq : public Requirement {
   private:


### PR DESCRIPTION
Similarly to #54, the requirement of having kernel.perf_event_paranoid set to -1 is not necessary if the patched "perf" executable has the CAP_IPC_LOCK and CAP_SYSLOG capabilities set to permissive and effective, in addition to CAP_PERFMON and CAP_BPF.

Because changing the value of kernel.perf_event_paranoid can also be an obstacle in adopting Adaptyst in more security-aware environments, this PR removes the requirement.

The documentation will be updated accordingly after the container images are deployed by the CI/CD pipeline.