### PR TITLE
Add support for cache-aware roofline profiling through the CARM Tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A comprehensive and architecture-agnostic performance analysis tool (formerly AdaptivePerf).
 
 ## Disclaimer
-This is currently a dev version and the tool is under active development. The test coverage is currently limited to the backend (adaptyst-server) only and bugs are to be expected. Use at your own risk!
+This is currently a dev version and the tool is under active development. The tests are limited at the moment and bugs are to be expected. Use at your own risk!
 
 All feedback is welcome.
 

--- a/docs/MAINPAGE.md
+++ b/docs/MAINPAGE.md
@@ -6,15 +6,11 @@ To get started, please:
 2. Go through the source code, starting with ```entrypoint.hpp```/```entrypoint.cpp``` inside ```src``` and ```src/server``` and using the documentation along the way to get to know the specific classes and functions (you can browse "Namespaces" and "Classes" for this purpose).
 
 ### Preprocessor definitions
-These are the CMake-set preprocessor definitions you should be aware of:
+These are the CMake-set Adaptyst-specific (i.e. non-Boost) preprocessor definitions you should be aware of:
 * ```SERVER_ONLY```: set when Adaptyst is compiled only with the backend component (i.e. adaptyst-server).
 * ```LIBNUMA_AVAILABLE```: set when Adaptyst is compiled with libnuma support.
 * ```ADAPTYST_CONFIG_FILE```: the path to the Adaptyst config file, CMake sets it to ```/etc/adaptyst.conf``` by default.
 * ```ADAPTYST_SCRIPT_PATH```: the path to the directory with Adaptyst "perf" Python scripts, CMake sets it to ```/opt/adaptyst``` by default.
-
-### Adaptyst config file
-In the current version, there is only one field in the Adaptyst config file:
-* ```perf_path```: the path to an installation directory of the Adaptyst-patched "perf" (with ```bin``` etc. directories inside). In case of no changes to the installation options, this is ```/opt/adaptyst/perf``` by default.
 
 ### Tests
 Making sure the tests pass and updating these when needed is crucial during the Adaptyst development. They are implemented using [the GoogleTest framework](https://github.com/google/googletest) and their codes are stored inside the ```test``` directory.

--- a/src/entrypoint.cpp
+++ b/src/entrypoint.cpp
@@ -9,6 +9,7 @@
 #include "cmd.hpp"
 #include <boost/algorithm/string.hpp>
 #include <boost/program_options/parsers.hpp>
+#include <boost/predef.h>
 #include <regex>
 #include <sys/wait.h>
 
@@ -170,6 +171,15 @@ namespace adaptyst {
       ->option_text("EVENT,PERIOD,TITLE")
       ->take_all();
 
+#ifdef BOOST_ARCH_X86
+    unsigned int roofline_freq = 0;
+    app.add_option("-r,--roofline", roofline_freq, "Add perf events for "
+                   "cache-aware roofline profiling with the specified sampling "
+                   "frequency per second (default: 0 meaning \"disabled\")")
+      ->check(OnlyMinRange(0))
+      ->option_text("UINT");
+#endif
+
     quiet = false;
     app.add_flag("-q,--quiet", quiet, "Do not print anything (if set, check "
                  "exit code for any errors)");
@@ -305,6 +315,21 @@ namespace adaptyst {
                                                  "Thread tree profiler"));
       profilers.push_back(std::make_unique<Perf>(perf_path, main, cpu_config,
                                                  "On-CPU/Off-CPU profiler"));
+
+#ifdef BOOST_ARCH_X86
+      if (roofline_freq > 0) {
+        std::string freq = std::to_string(roofline_freq);
+        event_strs.push_back("fp_arith_inst_retired.scalar_single," + freq + ",CARM_SSP");
+        event_strs.push_back("fp_arith_inst_retired.scalar_double," + freq + ",CARM_SDP");
+        event_strs.push_back("fp_arith_inst_retired.128b_packed_single," + freq + ",CARM_SSESP");
+        event_strs.push_back("fp_arith_inst_retired.128b_packed_double," + freq + ",CARM_SSEDP");
+        event_strs.push_back("fp_arith_inst_retired.256b_packed_single," + freq + ",CARM_AVX2SP");
+        event_strs.push_back("fp_arith_inst_retired.256b_packed_double," + freq + ",CARM_AVX2DP");
+        event_strs.push_back("fp_arith_inst_retired.512b_packed_single," + freq + ",CARM_AVX512SP");
+        event_strs.push_back("fp_arith_inst_retired.512b_packed_double," + freq + ",CARM_AVX512DP");
+        event_strs.push_back("mem_inst_retired.any," + freq + ",CARM_MEM_LDST");
+      }
+#endif
 
       std::unordered_map<std::string, std::string> event_dict;
 

--- a/src/process.hpp
+++ b/src/process.hpp
@@ -18,6 +18,7 @@ namespace adaptyst {
     std::vector<std::string> command;
     std::vector<std::pair<std::string, std::string> > env;
     bool stdout_redirect;
+    bool stdout_terminal;
     fs::path stdout_path;
     bool stderr_redirect;
     fs::path stderr_path;
@@ -51,8 +52,10 @@ namespace adaptyst {
     ~Process();
     void add_env(std::string key, std::string value);
     void set_redirect_stdout(fs::path path);
+    void set_redirect_stdout_to_terminal();
     void set_redirect_stdout(Process &process);
     void set_redirect_stderr(fs::path path);
+    int start(fs::path working_path = fs::current_path());
     int start(bool wait_for_notify,
               const CPUConfig &cpu_config,
               bool is_profiler,

--- a/src/profiling.cpp
+++ b/src/profiling.cpp
@@ -1074,7 +1074,7 @@ namespace adaptyst {
       }
 
       if (rl_result_path != nullptr) {
-        if (!fs::copy_file(*rl_result_path, result_processed)) {
+        if (!fs::copy_file(*rl_result_path, result_processed / "roofline.csv")) {
           print("Could not copy the roofline benchmarking results to the profiling "
                 "session result directory! Exiting.", true, true);
           return 2;

--- a/src/profiling.cpp
+++ b/src/profiling.cpp
@@ -426,8 +426,6 @@ namespace adaptyst {
           print("An unknown error has occurred in adaptyst-server! If the issue persists, "
                 "please contact the Adaptyst developers, citing \"" +
                 std::string(e.what()) + "\".", true, true);
-          print("For investigating what has gone wrong, you can check the files created in " +
-                tmp_dir.string() + ".", false, true);
           std::exit(2);
         }
       });
@@ -464,8 +462,8 @@ namespace adaptyst {
     }
 
     print("Waiting for profilers to signal their readiness. If Adaptyst "
-          "hangs here, you may want to check the files in " +
-          tmp_dir.string() + ".", true, false);
+          "hangs here, you may want to check the files in the "
+          "temporary directory.", true, false);
 
     auto profiler_and_wrapper_handler =
       [&](int code, long start_time, long end_time) {

--- a/src/profiling.hpp
+++ b/src/profiling.hpp
@@ -205,7 +205,8 @@ namespace adaptyst {
                               CPUConfig &cpu_config, fs::path tmp_dir,
                               std::vector<pid_t> &spawned_children,
                               std::unordered_map<std::string, std::string> &event_dict,
-                              std::string codes_dst);
+                              std::string codes_dst,
+                              fs::path *roofline_benchmark_path);
 };
 
 #endif


### PR DESCRIPTION
This PR adds end-to-end integration with [the CARM Tool](https://github.com/champ-hub/carm-roofline), allowing Adaptyst to perform cache-aware roofline profiling nearly automatically. Currently, only x86-64 is supported and AMD CPU profiling is marked as very experimental since appropriate AMD-based machines for testing will become available to us only in the next few days/weeks.