### PR TITLE
Add stack filtering and other updates

### DIFF
--- a/src/entrypoint.cpp
+++ b/src/entrypoint.cpp
@@ -30,14 +30,14 @@ namespace adaptyst {
   class OnlyMinRange : public CLI::Validator {
   public:
     OnlyMinRange(int min) {
-      func_ = [=](const std::string &arg) {
+      func_ = [=](const std::string &arg) -> std::string {
         if (!std::regex_match(arg, std::regex("^-?[0-9]+$")) ||
             std::stoi(arg) < min) {
           return "The value must be a number equal to or greater than " +
             std::to_string(min);
         }
 
-        return std::string();
+        return "";
       };
     }
   };
@@ -101,12 +101,13 @@ namespace adaptyst {
       ->option_text("UINT");
 
     std::string address = "";
-    app.add_option("-a,--address", address, "Delegate processing to "
-                   "another machine running adaptyst-server. All results "
-                   "will be stored on that machine.")
-      ->check([](const std::string &arg) {
+    auto addr_opt =
+      app.add_option("-a,--address", address, "Delegate processing to "
+                     "another machine running adaptyst-server. All results "
+                     "will be stored on that machine.")
+      ->check([](const std::string &arg) -> std::string {
         if (!std::regex_match(arg, std::regex("^.+\\:[0-9]+$"))) {
-          return "The value must be in form of \"<address>:<port>\".";
+          return "The value must be in form of \"<address>:<port>\"";
         }
 
         return "";
@@ -124,10 +125,10 @@ namespace adaptyst {
                    "and can be then read e.g. by adaptyst-code), or "
                    "\"fd:<number>\" (i.e. the list is written to a specified "
                    "file descriptor).")
-      ->check([](const std::string &arg) {
+      ->check([](const std::string &arg) -> std::string {
         if (!std::regex_match(arg, std::regex("^(file\\:.+|fd:\\d+|srv)$"))) {
           return "The value must be in form of \"srv\", \"file:<path>\", or "
-            "\"fd:<number>\".";
+            "\"fd:<number>\"";
         }
 
         return "";
@@ -140,7 +141,7 @@ namespace adaptyst {
                    "Not to be used with -a. (default when no -a: 1024)")
       ->check(OnlyMinRange(1))
       ->option_text("UINT>0")
-      ->excludes("-a");
+      ->excludes(addr_opt);
 
     unsigned int warmup = 1;
     app.add_option("-w,--warmup", warmup, "Warmup time in seconds between "
@@ -160,20 +161,20 @@ namespace adaptyst {
                    "\"perf list\" for the list of possible events. You "
                    "can specify multiple events by specifying this option "
                    "more than once. Use quotes if you need to use spaces.")
-      ->check([](const std::string &arg) {
+      ->check([](const std::string &arg) -> std::string {
         std::smatch match;
 
         if (!std::regex_match(arg, match, std::regex("^.+,[0-9\\.]+,(.+)$"))) {
           return "The value \"" + arg + "\" must be in form of EVENT,PERIOD,TITLE "
-            "(PERIOD must be a number).";
+            "(PERIOD must be a number)";
         }
 
         if (std::regex_match(match[1].str(), std::regex("^CARM_.*$"))) {
           return "The title in \"" + arg + "\" starts with a reserved keyword "
-            "CARM_, you cannot use it.";
+            "CARM_, you cannot use it";
         }
 
-        return std::string();
+        return "";
       })
       ->option_text("EVENT,PERIOD,TITLE")
       ->take_all();
@@ -186,6 +187,61 @@ namespace adaptyst {
       ->check(OnlyMinRange(1))
       ->option_text("UINT>0");
 #endif
+
+    std::string filter_str = "";
+    auto filter_opt =
+      app.add_option("-i,--filter", filter_str, "Set stack trace filtering "
+                     "options. deny:<FILE> cuts all stack elements "
+                     "matching a set of conditions specified in a given "
+                     "text file (use - for stdin). allow:<FILE> accepts "
+                     "only stack elements matching a set of conditions "
+                     "specified in a given text file (use - for stdin). "
+                     "python:<FILE> sends all stack trace elements to "
+                     "a given Python script for filtering. Unless -k is "
+                     "used, all filtered out elements are deleted "
+                     "completely. See the Adaptyst documentation to check "
+                     "in detail how to use filtering.")
+      ->check([](const std::string &arg) -> std::string {
+        std::smatch match;
+
+        if (!std::regex_match(arg, match,
+                              std::regex("^(deny|allow|python)\\:(.+)$"))) {
+          return "The value must be one of the following: "
+            "deny:<FILE>, allow:<FILE>, python:<FILE>";
+        }
+
+        if (match[2] == "-") {
+          if (match[1] == "python") {
+            return "stdin is not accepted for python";
+          }
+
+          return "";
+        }
+
+        return CLI::ExistingFile(match[2].str());
+      })
+      ->option_text("TYPE:FILE");
+
+    bool mark = false;
+    app.add_flag("-k,--mark", mark, "When -i is used, mark "
+                 "filtered out stack trace elements as \"(cut)\" and "
+                 "squash any consecutive \"(cut)\"'s into one rather "
+                 "than deleting them completely")
+      ->needs(filter_opt);
+
+    std::string capture_mode = "user";
+    app.add_option("-m,--mode", capture_mode,
+                   "Capture only kernel, only "
+                   "user (i.e. non-kernel), or both stack trace types "
+                   "respectively (default: \"user\")")
+      ->option_text("kernel OR user OR both")
+      ->check([](const std::string &arg) {
+        if (arg != "kernel" && arg != "user" && arg != "both") {
+          return "The value can be either \"kernel\", \"user\", or \"both\".";
+        }
+
+        return "";
+      });
 
     quiet = false;
     app.add_flag("-q,--quiet", quiet, "Do not print anything (if set, check "
@@ -339,6 +395,103 @@ namespace adaptyst {
         return 2;
       }
 
+      Perf::Filter filter;
+      std::string allowdenylist_path;
+      std::string allowdenylist_type;
+
+      filter.mode = Perf::FilterMode::NONE;
+      filter.mark = mark;
+
+      if (filter_str != "") {
+        std::smatch match;
+
+        if (!std::regex_match(filter_str, match,
+                              std::regex("^(deny|allow|python)\\:(.+)$"))) {
+          print("The value of --filter is incorrect, this shouldn't happen! "
+                "Exiting.", false, true);
+          return 2;
+        }
+
+        if (match[1] == "allow") {
+          filter.mode = Perf::FilterMode::ALLOW;
+          allowdenylist_path = match[2];
+          allowdenylist_type = "allowlist";
+        } else if (match[1] == "deny") {
+          filter.mode = Perf::FilterMode::DENY;
+          allowdenylist_path = match[2];
+          allowdenylist_type = "denylist";
+        } else {
+          filter.mode = Perf::FilterMode::PYTHON;
+          filter.data = fs::canonical(match[2].str());
+        }
+      }
+
+      if (allowdenylist_path != "") {
+        std::vector<std::vector<std::string > > allowdenylist;
+        print("Reading " + allowdenylist_type + "...",
+              false, false);
+
+        auto process_stream =
+          [](std::istream &stream,
+             std::vector<std::vector<std::string> > &list) {
+            std::vector<std::string> elements;
+            int line = 1;
+            while (stream) {
+              std::string input = "";
+              std::getline(stream, input);
+
+              if (input.length() > 0 && input[0] != '#') {
+                if (input == "OR") {
+                  list.push_back(elements);
+                  elements.clear();
+                } else if (std::regex_match(input,
+                                            std::regex("^(SYM|EXEC|ANY) .+$"))) {
+                  elements.push_back(input);
+                } else {
+                  print("Line " + std::to_string(line) + " is non-empty and "
+                        "invalid! Exiting.", true, true);
+                  return 2;
+                }
+              }
+
+              line++;
+            }
+
+            if (!elements.empty()) {
+              list.push_back(elements);
+            }
+
+            return 0;
+          };
+
+        int result = 0;
+
+        if (allowdenylist_path == "-") {
+          if (!std::cin) {
+            print("Cannot read stdin! Exiting.", true, true);
+            return 2;
+          }
+
+          result = process_stream(std::cin, allowdenylist);
+        } else {
+          std::ifstream stream(allowdenylist_path);
+
+          if (!stream) {
+            print("Cannot read " + allowdenylist_path + "! Exiting.",
+                  true, true);
+            return 2;
+          }
+
+          result = process_stream(stream, allowdenylist);
+        }
+
+        if (result != 0) {
+          return result;
+        }
+
+        filter.data = allowdenylist;
+      }
+
       print("Creating temporary directory...", false, false);
 
       pid_t current_pid = getpid();
@@ -384,14 +537,26 @@ namespace adaptyst {
       std::unique_ptr<Acceptor> acceptor2 =
           generic_acceptor_factory.make_acceptor(1);
 
+      Perf::CaptureMode mode;
+
+      if (capture_mode == "kernel") {
+        mode = Perf::CaptureMode::KERNEL;
+      } else if (capture_mode == "user") {
+        mode = Perf::CaptureMode::USER;
+      } else {
+        mode = Perf::CaptureMode::BOTH;
+      }
+
       profilers.push_back(std::make_unique<Perf>(acceptor1,
                                                  server_buffer,
                                                  perf_path, syscall_tree, cpu_config,
-                                                 "Thread tree profiler"));
+                                                 "Thread tree profiler",
+                                                 mode, filter));
       profilers.push_back(std::make_unique<Perf>(acceptor2,
                                                  server_buffer,
                                                  perf_path, main, cpu_config,
-                                                 "On-CPU/Off-CPU profiler"));
+                                                 "On-CPU/Off-CPU profiler",
+                                                 mode, filter));
 
       std::unique_ptr<fs::path> roofline_benchmark_path;
 
@@ -558,7 +723,7 @@ namespace adaptyst {
         profilers.push_back(std::make_unique<Perf>(acceptor,
                                                    server_buffer,
                                                    perf_path, event, cpu_config,
-                                                   event_name));
+                                                   event_name, mode, filter));
 
         event_dict[event_name] = website_title;
       }

--- a/src/entrypoint.cpp
+++ b/src/entrypoint.cpp
@@ -191,6 +191,15 @@ namespace adaptyst {
     app.add_flag("-q,--quiet", quiet, "Do not print anything (if set, check "
                  "exit code for any errors)");
 
+    std::string footer =
+      "If you want to change the paths of the system-wide and local Adaptyst\n"
+      "configuration files, set the environment variables ADAPTYST_CONFIG and\n"
+      "ADAPTYST_LOCAL_CONFIG respectively to values of your choice. Similarly,\n"
+      "you can set the ADAPTYST_SCRIPT_DIR environment variable to change the path\n"
+      "where Adaptyst looks for its Python scripts.";
+
+    app.footer(footer);
+
     bool call_split_unix = true;
 
     for (int i = 0; i < argc; i++) {
@@ -245,10 +254,8 @@ namespace adaptyst {
 
       print_notice();
 
-      print("Reading config file...", false, false);
+      print("Reading config file(s)...", false, false);
 
-      fs::path local_config_path = fs::path(getenv("HOME")) /
-        ".adaptyst" / "adaptyst.conf";
       std::unordered_map<std::string, std::string> config;
 
       auto read_config = [](fs::path config_path,
@@ -289,7 +296,19 @@ namespace adaptyst {
         return true;
       };
 
-      if (!read_config(ADAPTYST_CONFIG_FILE, config) ||
+      fs::path system_config_path(ADAPTYST_CONFIG_FILE);
+      fs::path local_config_path = fs::path(getenv("HOME")) /
+        ".adaptyst" / "adaptyst.conf";
+
+      if (getenv("ADAPTYST_CONFIG")) {
+        system_config_path = fs::path(getenv("ADAPTYST_CONFIG"));
+      }
+
+      if (getenv("ADAPTYST_LOCAL_CONFIG")) {
+        local_config_path = fs::path(getenv("ADAPTYST_LOCAL_CONFIG"));
+      }
+
+      if (!read_config(system_config_path, config) ||
           !read_config(local_config_path, config)) {
         return 2;
       }

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -390,4 +390,12 @@ namespace adaptyst {
     throw Process:NotImplementedException();
 #endif
   }
+
+  void Process::terminate() {
+#ifdef BOOST_OS_UNIX
+    kill(this->id, SIGTERM);
+#else
+    throw Process::NotImplementedException();
+#endif
+  }
 };

--- a/src/process.hpp
+++ b/src/process.hpp
@@ -66,6 +66,7 @@ namespace adaptyst {
     int join();
     bool is_running();
     void close_stdin();
+    void terminate();
 
     class NotifyException : public std::exception { };
     class NotReadableException : public std::exception { };

--- a/src/profilers.cpp
+++ b/src/profilers.cpp
@@ -114,6 +114,9 @@ namespace adaptyst {
     std::vector<std::string> argv_record;
     std::vector<std::string> argv_script;
 
+    std::string script_path =
+      getenv("ADAPTYST_SCRIPT_DIR") ? getenv("ADAPTYST_SCRIPT_DIR") : ADAPTYST_SCRIPT_PATH;
+
     if (this->perf_event.name == "<thread_tree>") {
       stdout = result_out / "perf_script_syscall_stdout.log";
       stderr_record = result_out / "perf_record_syscall_stderr.log";
@@ -124,7 +127,7 @@ namespace adaptyst {
                      "syscalls:sys_exit_execve,syscalls:sys_exit_execveat,"
                      "sched:sched_process_fork,sched:sched_process_exit",
                      "--sorted-stream", "--pid=" + std::to_string(pid)};
-      argv_script = {perf_path.string(), "script", "-s", ADAPTYST_SCRIPT_PATH "/adaptyst-syscall-process.py",
+      argv_script = {perf_path.string(), "script", "-s", script_path + "/adaptyst-syscall-process.py",
                      "--demangle", "--demangle-kernel",
                      "--max-stack=" + std::to_string(this->max_stack)};
     } else if (this->perf_event.name == "<main>") {
@@ -139,7 +142,7 @@ namespace adaptyst {
                      "--buffer-events", this->perf_event.options[2],
                      "--buffer-off-cpu-events", this->perf_event.options[3],
                      "--pid=" + std::to_string(pid)};
-      argv_script = {perf_path.string(), "script", "-s", ADAPTYST_SCRIPT_PATH "/adaptyst-process.py",
+      argv_script = {perf_path.string(), "script", "-s", script_path + "/adaptyst-process.py",
                      "--demangle", "--demangle-kernel",
                      "--max-stack=" + std::to_string(this->max_stack)};
     } else {
@@ -152,7 +155,7 @@ namespace adaptyst {
                      this->perf_event.name + "/period=" + this->perf_event.options[0] + "/",
                      "--buffer-events", this->perf_event.options[1],
                      "--pid=" + std::to_string(pid)};
-      argv_script = {perf_path.string(), "script", "-s", ADAPTYST_SCRIPT_PATH "/adaptyst-process.py",
+      argv_script = {perf_path.string(), "script", "-s", script_path + "/adaptyst-process.py",
                      "--demangle", "--demangle-kernel",
                      "--max-stack=" + std::to_string(this->max_stack)};
     }

--- a/src/profilers.hpp
+++ b/src/profilers.hpp
@@ -15,6 +15,7 @@
 #include <cstdlib>
 #include <unordered_map>
 #include <unordered_set>
+#include <variant>
 
 namespace adaptyst {
   namespace fs = std::filesystem;

--- a/src/profilers.hpp
+++ b/src/profilers.hpp
@@ -60,9 +60,12 @@ namespace adaptyst {
     int max_stack;
     std::unique_ptr<Process> record_proc;
     std::unique_ptr<Process> script_proc;
+    bool running;
 
   public:
-    Perf(fs::path perf_path,
+    Perf(std::unique_ptr<Acceptor> &acceptor,
+         unsigned int buf_size,
+         fs::path perf_path,
          PerfEvent &perf_event,
          CPUConfig &cpu_config,
          std::string name);

--- a/src/profilers.hpp
+++ b/src/profilers.hpp
@@ -50,6 +50,27 @@ namespace adaptyst {
      A class describing a Linux "perf" profiler.
   */
   class Perf : public Profiler {
+  public:
+    enum CaptureMode {
+      KERNEL,
+      USER,
+      BOTH
+    };
+
+    enum FilterMode {
+      ALLOW,
+      DENY,
+      PYTHON,
+      NONE
+    };
+
+    struct Filter {
+      FilterMode mode;
+      bool mark;
+      std::variant<fs::path,
+                   std::vector<std::vector<std::string> > > data;
+    };
+
   private:
     fs::path perf_path;
     std::future<int> process;
@@ -60,6 +81,8 @@ namespace adaptyst {
     int max_stack;
     std::unique_ptr<Process> record_proc;
     std::unique_ptr<Process> script_proc;
+    CaptureMode capture_mode;
+    Filter filter;
     bool running;
 
   public:
@@ -68,7 +91,9 @@ namespace adaptyst {
          fs::path perf_path,
          PerfEvent &perf_event,
          CPUConfig &cpu_config,
-         std::string name);
+         std::string name,
+         CaptureMode capture_mode,
+         Filter filter);
     ~Perf() {}
     std::string get_name();
     void start(pid_t pid,

--- a/src/profiling.cpp
+++ b/src/profiling.cpp
@@ -293,8 +293,15 @@ namespace adaptyst {
      @param event_dict       A dictionary mapping custom "perf" event names to their website
                              titles (e.g. "page-faults" -> "Page faults"). This dictionary will
                              be saved to event_dict.data in the "processed" directory.
-     @param codes_dst        TODO
-     @param rl_result_path   TODO
+     @param codes_dst        A string specifying what to do with source code file paths
+                             detected during profiling. It can be either "srv" (i.e. the server
+                             receives the list, looks for the files there, and creates a source
+                             code archive there as well), "file:<path>" (i.e. the list is
+                             saved to <path> and can be then read e.g. by adaptyst-code), or
+                             "fd:<number>" (i.e. the list is written to a specified file
+                             descriptor).
+     @param rl_result_path   A pointer to the path to roofline benchmarking results produced
+                             by the CARM Tool. Can be null.
   */
   int start_profiling_session(std::vector<std::unique_ptr<Profiler> > &profilers,
                               std::vector<std::string> &command_elements,

--- a/src/profiling.cpp
+++ b/src/profiling.cpp
@@ -383,9 +383,9 @@ namespace adaptyst {
     spawned_children.push_back(wrapper_id);
 
     if (server_address == "") {
-      print("Starting adaptyst-server and profilers...", true, false);
+      print("Starting adaptyst-server...", true, false);
     } else {
-      print("Connecting to adaptyst-server and starting profilers...", true, false);
+      print("Connecting to adaptyst-server...", true, false);
     }
 
     std::unique_ptr<Connection> connection;
@@ -456,16 +456,16 @@ namespace adaptyst {
       return 2;
     }
 
+    print("Starting profilers and waiting for them to signal their "
+          "readiness. If Adaptyst hangs here, you may want to check "
+          "the files in the temporary directory.", true, false);
+
     ServerConnInstrs connection_instrs(all_connection_instrs);
 
     for (int i = 0; i < profilers.size(); i++) {
       profilers[i]->start(wrapper_id, connection_instrs, result_out,
                           result_processed, true);
     }
-
-    print("Waiting for profilers to signal their readiness. If Adaptyst "
-          "hangs here, you may want to check the files in the "
-          "temporary directory.", true, false);
 
     auto profiler_and_wrapper_handler =
       [&](int code, long start_time, long end_time) {

--- a/src/profiling.hpp
+++ b/src/profiling.hpp
@@ -207,7 +207,7 @@ namespace adaptyst {
                               std::vector<pid_t> &spawned_children,
                               std::unordered_map<std::string, std::string> &event_dict,
                               std::string codes_dst,
-                              fs::path *roofline_benchmark_path);
+                              fs::path *rl_result_path);
 };
 
 #endif

--- a/src/profiling.hpp
+++ b/src/profiling.hpp
@@ -109,6 +109,21 @@ namespace adaptyst {
     unsigned int buf_size;
 
   public:
+    /**
+       Constructs a Profiler object with
+       the acceptor used for establishing a connection for
+       exchanging generic messages with the profiler.
+
+       @param acceptor The acceptor to use.
+       @param buf_size The buffer size for a connection that the
+                       acceptor will accept.
+    */
+    Profiler(std::unique_ptr<Acceptor> &acceptor,
+             unsigned int buf_size) {
+      this->acceptor = std::move(acceptor);
+      this->buf_size = buf_size;
+    }
+
     virtual ~Profiler() { }
 
     /**
@@ -172,25 +187,11 @@ namespace adaptyst {
     virtual std::vector<std::unique_ptr<Requirement> > &get_requirements() = 0;
 
     /**
-       Sets the acceptor used for establishing a connection for
-       exchanging generic messages with the profiler.
-
-       @param acceptor The acceptor to use.
-       @param buf_size The buffer size for a connection that the
-                       acceptor will accept.
-    */
-    void set_acceptor(std::unique_ptr<Acceptor> &acceptor,
-                      unsigned int buf_size) {
-      this->acceptor = std::move(acceptor);
-      this->buf_size = buf_size;
-    }
-
-    /**
        Gets the connection used for exchanging generic messages with
        the profiler.
 
        WARNING: A null pointer will be returned if start() hasn't been
-       called before or the acceptor is not set via set_acceptor().
+       called before.
     */
     std::unique_ptr<Connection> &get_connection() {
       return this->connection;

--- a/src/scripts/adaptyst-syscall-process.py
+++ b/src/scripts/adaptyst-syscall-process.py
@@ -11,6 +11,10 @@ import re
 import json
 import subprocess
 import socket
+import importlib.util
+import select
+from cxxfilt import demangle
+from bisect import bisect_left
 from pathlib import Path
 from collections import defaultdict
 
@@ -41,7 +45,18 @@ frontend_stream = None
 tid_dict = {}
 symbol_dict = defaultdict(lambda: next_code(cur_code_sym))
 dso_dict = defaultdict(set)
-perf_map_paths = set()
+perf_maps = {}
+filter_settings = None
+
+
+# import_from_path is from
+# https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly
+def import_from_path(module_name, file_path):
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 def write(stream, msg):
@@ -54,6 +69,69 @@ def write(stream, msg):
             stream.write(msg + '\n')
 
         stream.flush()
+
+
+def find_in_map(map_path, map_id, ip):
+    global perf_maps
+
+    if map_id not in perf_maps:
+        if map_path.exists():
+            perf_maps[map_id] = (map_path,
+                                 map_path.open(mode='r'), [0], [])
+        else:
+            perf_maps[map_id] = (map_path, None, None, None)
+            return None
+
+    _, f, i, groups = perf_maps[map_id]
+
+    if f is None:
+        return None
+
+    for group in groups:
+        index = bisect_left(group, ip,
+                            key=lambda x: x[0])
+
+        if index < len(group) and group[index][0] <= ip and \
+           group[index][0] + group[index][1] > ip:
+            return group[index][2]
+
+    ready, _, _ = select.select([f], [], [], 0)
+    to_add = []
+
+    while f in ready:
+        line = next(f).strip()
+        i[0] += 1
+
+        match = re.search(
+            r'^([0-9a-fA-F]+)\s+([0-9a-fA-F]+)\s+(.+)$', line)
+
+        if match is None:
+            print(f'Line {i[0]}, {map_path}: '
+                  'incorrect syntax, ignoring.',
+                  file=sys.stderr)
+            ready, _, _ = select.select([f], [], [], 0)
+            continue
+
+        data = (int(match.group(1), 16),
+                int(match.group(2), 16),
+                demangle(match.group(3), False))
+
+        to_add.append(data)
+
+        if data[0] <= ip and data[0] + data[1] > ip:
+            if len(to_add) > 0:
+                to_add.sort(key=lambda x: x[0])
+                perf_maps[map_id][-1].append(to_add)
+
+            return data[2]
+
+        ready, _, _ = select.select([f], [], [], 0)
+
+    if len(to_add) > 0:
+        to_add.sort(key=lambda x: x[0])
+        perf_maps[map_id][-1].append(to_add)
+
+    return None
 
 
 def syscall_callback(stack, ret_value):
@@ -70,32 +148,103 @@ def syscall_callback(stack, ret_value):
     # The dictionary mapping compressed names to full ones
     # is saved at the end of profiling to syscall_callchains.json
     # (see reverse_callchain_dict in trace_end()).
-    #
-    # Also, if a symbol name is detected to come from a perf symbol
-    # map (i.e. the name of an executable/library is in form of
-    # perf-<number>.map), the path to the map is saved so that Adaptyst
-    # can copy it to the profiling results directory later.
     def process_callchain_elem(elem):
         sym_result = [f'[{elem["ip"]:#x}]', '']
+        sym_result_set = False
         off_result = hex(elem['ip'])
 
         if 'dso' in elem:
             p = Path(elem['dso'])
-            if re.search(r'^perf\-\d+\.map$', p.name) is not None:
-                perf_map_paths.add(str(p))
-                sym_result[1] = p.name
+            perf_map_match = re.search(r'^perf\-(\d+)\.map$', p.name)
+            if perf_map_match is not None:
+                if 'sym' in elem and 'name' in elem['sym']:
+                    sym_result[0] = demangle(elem['sym']['name'], False)
+                    sym_result_set = True
+                else:
+                    result = find_in_map(p, perf_map_match.group(1), elem['ip'])
+                    if result is not None:
+                        sym_result[0] = result
+                        sym_result_set = True
             else:
                 dso_dict[elem['dso']].add(hex(elem['dso_off']))
                 sym_result[0] = f'[{elem["dso"]}]'
-                sym_result[1] = elem['dso']
                 off_result = hex(elem['dso_off'])
 
-        if 'sym' in elem and 'name' in elem['sym']:
+            sym_result[1] = elem['dso']
+
+        if not sym_result_set and \
+           'sym' in elem and 'name' in elem['sym']:
             sym_result[0] = elem['sym']['name']
 
-        return symbol_dict[tuple(sym_result)], off_result
+        return tuple(sym_result), off_result
 
-    callchain = list(map(process_callchain_elem, stack))[::-1]
+    callchain_tmp = tuple(map(process_callchain_elem, stack))
+
+    if filter_settings is None:
+        callchain = [(symbol_dict[s], o) for s, o in callchain_tmp]
+    else:
+        callchain = []
+
+        def satisfy_conditions(sym_result, conditions):
+            for group in conditions:
+                matched = True
+                for cond in group:
+                    match = re.search(r'^(SYM|EXEC|ANY) (.+)$',
+                                      cond)
+
+                    cond_type = match.group(1)
+                    regex = match.group(2)
+
+                    if cond_type == 'SYM':
+                        if re.search(regex, sym_result[0]) is None:
+                            matched = False
+                            break
+                    elif cond_type == 'EXEC':
+                        if re.search(regex, sym_result[1]) is None:
+                            matched = False
+                            break
+                    elif cond_type == 'ANY':
+                        if re.search(regex, sym_result[0]) is None and \
+                           re.search(regex, sym_result[1]) is None:
+                            matched = False
+                            break
+
+                if matched:
+                    return True
+
+            return False
+
+        if filter_settings['type'] == 'python':
+            accepted = filter_settings['module'].process(callchain_tmp)
+
+            if accepted is None or not isinstance(accepted, list) or \
+               len(accepted) != len(callchain_tmp):
+                raise RuntimeError('Invalid value of process() from the ' +
+                                   'provided Python script: it is not ' +
+                                   f'a list of size {len(callchain_tmp)}')
+        else:
+            accepted = None
+
+        last_cut = False
+        for i, (sym_result, off_result) in enumerate(callchain_tmp):
+            if accepted is None:
+                satisfied = satisfy_conditions(sym_result,
+                                               filter_settings['conditions'])
+            else:
+                if not isinstance(accepted[i], bool):
+                    raise RuntimeError('Invalid value of process() from the ' +
+                                       'provided Python script: a non-boolean ' +
+                                       f'element at index {i}')
+
+                satisfied = accepted[i]
+
+            if (filter_settings['type'] in ['python', 'allow'] and satisfied) or \
+               (filter_settings['type'] == 'deny' and not satisfied):
+                callchain.append((symbol_dict[sym_result], off_result))
+                last_cut = False
+            elif filter_settings['mark'] and not last_cut:
+                callchain.append((symbol_dict[('(cut)', '')], ''))
+                last_cut = True
 
     write(event_stream, json.dumps({
         'type': 'syscall',
@@ -118,7 +267,37 @@ def syscall_tree_callback(syscall_type, comm_name, pid, tid, time,
 
 
 def trace_begin():
-    global event_stream, frontend_stream
+    global event_stream, frontend_stream, filter_settings
+
+    frontend_connect = os.environ['ADAPTYST_CONNECT'].split(' ')
+    instrs = frontend_connect[1:]
+    parts = instrs[0].split('_')
+
+    if frontend_connect[0] == 'pipe':
+        stream_read = os.fdopen(int(parts[0]), 'r')
+        stream = os.fdopen(int(parts[1]), 'w')
+        stream.write('connect')
+        stream.flush()
+        frontend_stream = stream
+
+        for line in stream_read:
+            line = line.strip()
+
+            if line == '<STOP>':
+                break
+
+            command = json.loads(line)
+
+            if command['type'] == 'filter_settings':
+                filter_settings = command['data']
+
+                if filter_settings['type'] == 'python':
+                    filter_settings['module'] = \
+                        import_from_path('module',
+                                         filter_settings['script'])
+                    filter_settings['module'].setup()
+
+        stream_read.close()
 
     serv_connect = os.environ['ADAPTYST_SERV_CONNECT'].split(' ')
     parts = serv_connect[1].split('_')
@@ -132,19 +311,9 @@ def trace_begin():
         event_stream.write('connect'.encode('ascii'))
         event_stream.flush()
 
-    frontend_connect = os.environ['ADAPTYST_CONNECT'].split(' ')
-    instrs = frontend_connect[1:]
-    parts = instrs[0].split('_')
-
-    if frontend_connect[0] == 'pipe':
-        stream = os.fdopen(int(parts[1]), 'w')
-        stream.write('connect')
-        stream.flush()
-        frontend_stream = stream
-
 
 def trace_end():
-    global event_stream, callchain_dict, perf_map_paths
+    global event_stream, callchain_dict, perf_map_paths, perf_maps
 
     write(event_stream, '<STOP>')
     event_stream.close()
@@ -159,9 +328,17 @@ def trace_end():
         'data': {k: list(v) for k, v in dso_dict.items()}
     }))
 
+    missing_maps = []
+
+    for map_path, f, _, _ in perf_maps.values():
+        if f is None:
+            missing_maps.append(str(map_path))
+        else:
+            f.close()
+
     write(frontend_stream, json.dumps({
-        'type': 'symbol_maps',
-        'data': list(perf_map_paths)
+        'type': 'missing_symbol_maps',
+        'data': missing_maps
     }))
 
     write(frontend_stream, '<STOP>')

--- a/src/scripts/cxxfilt.py
+++ b/src/scripts/cxxfilt.py
@@ -1,0 +1,136 @@
+# From https://github.com/afq984/python-cxxfilt/blob/master/cxxfilt/__init__.py
+# with modifications
+# Licensed under: https://github.com/afq984/python-cxxfilt/blob/master/LICENSE
+# (covered by GNU GPL v2 here)
+
+import abc
+import ctypes
+import ctypes.util
+
+from typing import Sequence, Union
+
+
+class Error(Exception):
+    pass
+
+
+class LibraryNotFound(Error):
+    pass
+
+
+class InternalError(Error):
+    pass
+
+
+class InvalidName(Error):
+    '''Exception raised when:
+    mangled_name is not a valid name under the C++ ABI mangling rules.'''
+
+    def __init__(self, mangled_name: Union[str, bytes]) -> None:
+        super(InvalidName, self).__init__()
+        self.mangled_name = mangled_name
+
+    def __str__(self) -> str:
+        return repr(self.mangled_name)
+
+
+class CharP(ctypes.c_char_p):
+    pass
+
+
+def find_any_library(*choices: str) -> str:
+    for choice in choices:
+        lib = ctypes.util.find_library(choice)
+        if lib is not None:
+            return lib
+    raise LibraryNotFound('Cannot find any of libraries: {}'.format(choices))
+
+
+class BaseDemangler(abc.ABC):
+    @abc.abstractmethod
+    def demangleb(self, mangled_name: bytes, external_only: bool = True) -> bytes:
+        raise NotImplementedError
+
+    def demangle(self, mangled_name: str, external_only: bool = True) -> str:
+        return self.demangleb(
+            mangled_name.encode(), external_only=external_only
+        ).decode()
+
+
+class Demangler(BaseDemangler):
+    def __init__(self, libc_name: str, libcxx_name: str) -> None:
+        assert isinstance(libc_name, str), libc_name
+        assert isinstance(libcxx_name, str), libcxx_name
+
+        self._libc_name = libc_name
+        libc = ctypes.CDLL(libc_name)
+        self._free = libc.free
+        self._free.argtypes = [ctypes.c_void_p]
+
+        self._libcxx_name = libcxx_name
+        libcxx = ctypes.CDLL(libcxx_name)
+        # use getattr to workaround with python's own name mangling
+        self._cxa_demangle = getattr(libcxx, '__cxa_demangle')
+        self._cxa_demangle.restype = CharP
+
+    def __repr__(self) -> str:
+        return f'<{self.__class__.__name__} libc={self._libc_name!r} libcxx={self._libcxx_name!r}>'
+
+    def demangleb(self, mangled_name: bytes, external_only: bool = True) -> bytes:
+        # Wikipedia: All *external* mangled symbols begin with _Z
+        if external_only and not mangled_name.startswith(b'_Z'):
+            return mangled_name
+
+        mangled_name_p = ctypes.c_char_p(mangled_name)
+        status = ctypes.c_int()
+        retval = self._cxa_demangle(mangled_name_p, None, None, ctypes.pointer(status))
+
+        try:
+            demangled = retval.value
+        finally:
+            self._free(retval)
+
+        if status.value == 0:
+            return demangled
+        elif status.value == -1:
+            raise InternalError('A memory allocation failiure occurred')
+        elif status.value == -2:
+            return mangled_name
+        elif status.value == -3:
+            raise InternalError('One of the arguments is invalid')
+        else:
+            raise InternalError('Unkwon status code: {}'.format(status.value))
+
+
+class DeferedErrorDemangler(BaseDemangler):
+    def __init__(self, error: Exception) -> None:
+        self._error = error
+
+    def demangleb(self, mangled_name: bytes, external_only: bool = True) -> bytes:
+        raise self._error
+
+
+def _get_default_demangler() -> BaseDemangler:
+    try:
+        libc = find_any_library('c')
+        libcxx = find_any_library('stdc++', 'c++')
+    except LibraryNotFound as error:
+        return DeferedErrorDemangler(error=error)
+    return Demangler(libc, libcxx)
+
+
+default_demangler: BaseDemangler = _get_default_demangler()
+
+
+def demangle(mangled_name: str, external_only: bool = True) -> str:
+    return default_demangler.demangle(
+        mangled_name=mangled_name,
+        external_only=external_only,
+    )
+
+
+def demangleb(mangled_name: bytes, external_only: bool = True) -> bytes:
+    return default_demangler.demangleb(
+        mangled_name=mangled_name,
+        external_only=external_only,
+    )

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -7,13 +7,13 @@ set -e
 if [[ "$1" == "uninstall" ]]; then
     if [[ -f prefix.txt ]]; then
         prefix=$(cat prefix.txt)
-        rm "$prefix"/adaptyst-*.py
+        rm "$prefix"/adaptyst-*.py "$prefix"/cxxfilt.py
         rm prefix.txt
     else
         echo "No prefix.txt found! Have you installed the scripts before?"
         exit 1
     fi
 else
-    cp adaptyst-syscall-process.py adaptyst-process.py "$1"
+    cp adaptyst-syscall-process.py adaptyst-process.py cxxfilt.py "$1"
     echo "$1" > prefix.txt
 fi

--- a/src/server/socket.hpp
+++ b/src/server/socket.hpp
@@ -179,8 +179,15 @@ namespace adaptyst {
 
        It should always return the new connection, regardless of the
        number of connections already accepted by the object.
+
+       @param buf_size The buffer size for communication, in bytes.
+       @param timeout  The maximum number of seconds the acceptor will
+                       wait for to accept a connection. Afterwards,
+                       TimeoutException will be thrown. Use NO_TIMEOUT
+                       to wait indefinitely for a connection.
     */
-    virtual std::unique_ptr<Connection> accept_connection(unsigned int buf_size) = 0;
+    virtual std::unique_ptr<Connection> accept_connection(unsigned int buf_size,
+                                                          long timeout) = 0;
 
     /**
        Closes the acceptor.
@@ -216,17 +223,24 @@ namespace adaptyst {
        a runtime error is thrown immediately.
 
        @param buf_size The buffer size for communication, in bytes.
+       @param timeout  The maximum number of seconds the acceptor
+                       will wait for to accept a connection. Afterwards,
+                       TimeoutException will be thrown. Use NO_TIMEOUT
+                       to wait indefinitely for a connection.
 
        @throw std::runtime_error When the maximum number of accepted
                                  connections is reached.
+       @throw TimeoutException   When the timeout is reached.
     */
-    std::unique_ptr<Connection> accept(unsigned int buf_size) {
+    std::unique_ptr<Connection> accept(unsigned int buf_size,
+                                       long timeout = NO_TIMEOUT) {
       if (this->max_accepted != UNLIMITED_ACCEPTED &&
           this->accepted >= this->max_accepted) {
         throw std::runtime_error("Maximum accepted connections reached.");
       }
 
-      std::unique_ptr<Connection> connection = this->accept_connection(buf_size);
+      std::unique_ptr<Connection> connection = this->accept_connection(buf_size,
+                                                                       timeout);
       this->accepted++;
 
       return connection;
@@ -290,7 +304,8 @@ namespace adaptyst {
                 bool try_subsequent_ports);
 
   protected:
-    std::unique_ptr<Connection> accept_connection(unsigned int buf_size);
+    std::unique_ptr<Connection> accept_connection(unsigned int buf_size,
+                                                  long timeout);
     void close();
 
   public:
@@ -378,7 +393,8 @@ namespace adaptyst {
     PipeAcceptor();
 
   protected:
-    std::unique_ptr<Connection> accept_connection(unsigned int buf_size);
+    std::unique_ptr<Connection> accept_connection(unsigned int buf_size,
+                                                  long timeout);
     void close();
 
   public:


### PR DESCRIPTION
This PR:
* adds stack filtering based on either a denylist, an allowlist, or a custom Python script
* adds a choice to collect either user stacks, kernel stacks, or both stacks during profiling (for all types of profiling)
* fixes Adaptyst not printing any meaningful messages when profilers crash in some cases
* adds an option of using a custom config path and a custom script path at runtime through environment variables
* implements miscellaneous updates: completing docs for ```start_profiling_session()``` and adding ```Process::terminate()```