### PR TITLE
Add CI based on LCG nightlies

### DIFF
--- a/.github/workflows/lcg.yaml
+++ b/.github/workflows/lcg.yaml
@@ -24,4 +24,4 @@ jobs:
           echo "::group::CMakeConfig"
           cmake ..
           echo "::group::Compile"
-          make
+          make VERBOSE=1

--- a/.github/workflows/lcg.yaml
+++ b/.github/workflows/lcg.yaml
@@ -12,9 +12,9 @@ jobs:
     - uses: aidasoft/run-lcg-view@v3
       with:
         container: "el9"
-        view-path: ""
+        view-path: "/cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Fri/Boost/1.87.0/x86_64-el9-gcc13-opt"
+        setup-script: "Boost-env.sh"
         run: |
-          source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Fri/Boost/1.87.0/x86_64-el9-gcc13-opt/Boost-env.sh
           source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Fri/libarchive/3.7.9/x86_64-el9-gcc13-opt/libarchive-env.sh
           mkdir build
           cd build

--- a/.github/workflows/lcg.yaml
+++ b/.github/workflows/lcg.yaml
@@ -17,6 +17,8 @@ jobs:
         run: |
           source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Fri/libarchive/3.7.9/x86_64-el9-gcc13-opt/libarchive-env.sh
           source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Mon/jsonmcpp/3.11.3/x86_64-el9-gcc13-opt/jsonmcpp-env.sh
+          source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Mon/poco/1.13.3/x86_64-el9-gcc13-opt/poco-env.sh
+          source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Mon/cli11/2.4.2/x86_64-el9-gcc13-opt/cli11-env.sh
           mkdir build
           cd build
           echo "::group::CMakeConfig"

--- a/.github/workflows/lcg.yaml
+++ b/.github/workflows/lcg.yaml
@@ -1,0 +1,20 @@
+name: linux
+
+on: [push, pull_request]
+
+jobs:
+
+  default:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: cvmfs-contrib/github-action-cvmfs@v4
+    - name: Compile
+      run: |
+          source /cvmfs/sft.cern.ch/lcg/views/dev4/latest/x86_64-el9-gcc13-opt/setup.sh
+          mkdir build
+          cd build
+          echo "::group::CMakeConfig"
+          cmake .. -G Ninja
+          echo "::group::Compile"
+          ninja

--- a/.github/workflows/lcg.yaml
+++ b/.github/workflows/lcg.yaml
@@ -19,6 +19,6 @@ jobs:
           mkdir build
           cd build
           echo "::group::CMakeConfig"
-          cmake .. -G Ninja
+          cmake ..
           echo "::group::Compile"
-          ninja
+          make

--- a/.github/workflows/lcg.yaml
+++ b/.github/workflows/lcg.yaml
@@ -12,7 +12,7 @@ jobs:
     - uses: aidasoft/run-lcg-view@v3
       with:
         view_path: /cvmfs/sft.cern.ch/lcg/views/dev4/latest/x86_64-el9-gcc13-opt/
-      run: |
+        run: |
           mkdir build
           cd build
           echo "::group::CMakeConfig"

--- a/.github/workflows/lcg.yaml
+++ b/.github/workflows/lcg.yaml
@@ -12,6 +12,7 @@ jobs:
     - uses: aidasoft/run-lcg-view@v3
       with:
         container: "el9"
+        view-path: ""
         run: |
           source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Fri/Boost/1.87.0/x86_64-el9-gcc13-opt/Boost-env.sh
           source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Fri/libarchive/3.7.9/x86_64-el9-gcc13-opt/libarchive-env.sh

--- a/.github/workflows/lcg.yaml
+++ b/.github/workflows/lcg.yaml
@@ -9,9 +9,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: cvmfs-contrib/github-action-cvmfs@v4
-    - name: Compile
+    - uses: aidasoft/run-lcg-view@v3
+      with:
+        view_path: /cvmfs/sft.cern.ch/lcg/views/dev4/latest/x86_64-el9-gcc13-opt/
       run: |
-          source /cvmfs/sft.cern.ch/lcg/views/dev4/latest/x86_64-el9-gcc13-opt/setup.sh
           mkdir build
           cd build
           echo "::group::CMakeConfig"

--- a/.github/workflows/lcg.yaml
+++ b/.github/workflows/lcg.yaml
@@ -24,4 +24,4 @@ jobs:
           echo "::group::CMakeConfig"
           cmake ..
           echo "::group::Compile"
-          make VERBOSE=1
+          make VERBOSE=1 -k

--- a/.github/workflows/lcg.yaml
+++ b/.github/workflows/lcg.yaml
@@ -11,7 +11,7 @@ jobs:
     - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: aidasoft/run-lcg-view@v3
       with:
-        container: el9
+        container: "el9"
         run: |
           source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Fri/Boost/1.87.0/x86_64-el9-gcc13-opt/Boost-env.sh
           source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Fri/libarchive/3.7.9/x86_64-el9-gcc13-opt/libarchive-env.sh

--- a/.github/workflows/lcg.yaml
+++ b/.github/workflows/lcg.yaml
@@ -11,7 +11,7 @@ jobs:
     - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: aidasoft/run-lcg-view@v3
       with:
-        release_platform: "dev4/x86_64-el9-gcc13-opt"
+        release-platform: "dev4/x86_64-el9-gcc13-opt"
         run: |
           mkdir build
           cd build

--- a/.github/workflows/lcg.yaml
+++ b/.github/workflows/lcg.yaml
@@ -11,8 +11,10 @@ jobs:
     - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: aidasoft/run-lcg-view@v3
       with:
-        release-platform: "dev4/x86_64-el9-gcc13-opt"
+        container: el9
         run: |
+          source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Fri/Boost/1.87.0/x86_64-el9-gcc13-opt/Boost-env.sh
+          source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Fri/libarchive/3.7.9/x86_64-el9-gcc13-opt/libarchive-env.sh
           mkdir build
           cd build
           echo "::group::CMakeConfig"

--- a/.github/workflows/lcg.yaml
+++ b/.github/workflows/lcg.yaml
@@ -11,7 +11,7 @@ jobs:
     - uses: cvmfs-contrib/github-action-cvmfs@v4
     - uses: aidasoft/run-lcg-view@v3
       with:
-        view_path: /cvmfs/sft.cern.ch/lcg/views/dev4/latest/x86_64-el9-gcc13-opt/
+        release_platform: "dev4/x86_64-el9-gcc13-opt"
         run: |
           mkdir build
           cd build

--- a/.github/workflows/lcg.yaml
+++ b/.github/workflows/lcg.yaml
@@ -16,6 +16,7 @@ jobs:
         setup-script: "Boost-env.sh"
         run: |
           source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Fri/libarchive/3.7.9/x86_64-el9-gcc13-opt/libarchive-env.sh
+          source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Mon/jsonmcpp/3.11.3/x86_64-el9-gcc13-opt/jsonmcpp-env.sh
           mkdir build
           cd build
           echo "::group::CMakeConfig"


### PR DESCRIPTION
This adds a build similar to what we would have when building inside LCGCmake.
The package locations are going to be very unstable until they are part of a release, or at least in latest. But at the moment this shows the issue of failing to find header files, even though the packages are found.

Run is here: https://github.com/andresailer/Adaptyst/actions/runs/14305206704/job/40087515931

E.g.:
```
   [ 16%] Building CXX object CMakeFiles/client.o.dir/src/server/client.cpp.o
  /cvmfs/sft.cern.ch/lcg/releases/gcc/13.1.0-b3d18/x86_64-el9/bin/g++  -I/home/runner/work/Adaptyst/Adaptyst/src -std=c++20 -fPIC -MD -MT CMakeFiles/client.o.dir/src/server/client.cpp.o -MF CMakeFiles/client.o.dir/src/server/client.cpp.o.d -o CMakeFiles/client.o.dir/src/server/client.cpp.o -c /home/runner/work/Adaptyst/Adaptyst/src/server/client.cpp
  In file included from /home/runner/work/Adaptyst/Adaptyst/src/server/server.hpp:7,
                   from /home/runner/work/Adaptyst/Adaptyst/src/server/client.cpp:4:
  /home/runner/work/Adaptyst/Adaptyst/src/server/socket.hpp:12:10: fatal error: Poco/Net/ServerSocket.h: No such file or directory
     12 | #include <Poco/Net/ServerSocket.h>
```

The file is here
```
/cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Mon/poco/1.13.3/x86_64-el9-gcc13-opt/include/Poco/Net/ServerSocket.h
```

But there is no `-I/-system` flag in the compiler call