### PR TITLE
Fix symbol map paths not being saved when the maps are missing

### DIFF
--- a/src/scripts/adaptyst-process.py
+++ b/src/scripts/adaptyst-process.py
@@ -237,7 +237,9 @@ def process_event(param_dict):
                     sym_result_set = True
                 else:
                     result = find_in_map(p, perf_map_match.group(1), elem['ip'])
-                    if result is not None:
+                    if result is None:
+                        sym_result[0] = f'[{elem["dso"]}]'
+                    else:
                         sym_result[0] = result
                         sym_result_set = True
             else:

--- a/src/scripts/adaptyst-syscall-process.py
+++ b/src/scripts/adaptyst-syscall-process.py
@@ -162,7 +162,9 @@ def syscall_callback(stack, ret_value):
                     sym_result_set = True
                 else:
                     result = find_in_map(p, perf_map_match.group(1), elem['ip'])
-                    if result is not None:
+                    if result is None:
+                        sym_result[0] = f'[{elem["dso"]}]'
+                    else:
                         sym_result[0] = result
                         sym_result_set = True
             else:


### PR DESCRIPTION
When symbol maps are expected during profiling and they are missing, an instruction pointer address is saved instead of the path where the map should have been found. This behaviour is incorrect and this PR fixes it.

(The GitHub CI pipeline is expected to fail, it's related to the CERN LCG Releases CVMFS deployment which is a separate issue)