### PR TITLE
CMake: use pkg-config to find numa, fix linking against numa in non-s…

### DIFF
--- a/.github/workflows/lcg.yaml
+++ b/.github/workflows/lcg.yaml
@@ -20,7 +20,6 @@ jobs:
           source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Mon/jsonmcpp/3.11.3/x86_64-el9-gcc14fp-opt/jsonmcpp-env.sh
           source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Mon/poco/1.14.1/x86_64-el9-gcc14fp-opt/poco-env.sh
           source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Mon/cli11/2.4.2/x86_64-el9-gcc14fp-opt/cli11-env.sh
-          source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Mon/libarchive/3.7.9/x86_64-el9-gcc14fp-opt/libarchive-env.sh
           source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Mon/libbpf/1.5.0/x86_64-el9-gcc14fp-opt/libbpf-env.sh
           source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Mon/libnuma/2.0.19/x86_64-el9-gcc14fp-opt/libnuma-env.sh
           source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Mon/libtraceevent/1.8.4/x86_64-el9-gcc14fp-opt/libtraceevent-env.sh

--- a/.github/workflows/lcg.yaml
+++ b/.github/workflows/lcg.yaml
@@ -1,7 +1,7 @@
 name: linux
 
 # on: [push, pull_request]
-on: []
+on: [push]
 
 jobs:
 
@@ -13,16 +13,24 @@ jobs:
     - uses: aidasoft/run-lcg-view@v3
       with:
         container: "el9"
-        view-path: "/cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Fri/Boost/1.87.0/x86_64-el9-gcc13-opt"
+        view-path: "/cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Mon/Boost/1.88.0/x86_64-el9-gcc14fp-opt"
         setup-script: "Boost-env.sh"
         run: |
-          source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Fri/libarchive/3.7.9/x86_64-el9-gcc13-opt/libarchive-env.sh
-          source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Mon/jsonmcpp/3.11.3/x86_64-el9-gcc13-opt/jsonmcpp-env.sh
-          source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Mon/poco/1.13.3/x86_64-el9-gcc13-opt/poco-env.sh
-          source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Mon/cli11/2.4.2/x86_64-el9-gcc13-opt/cli11-env.sh
+          source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Mon/libarchive/3.7.9/x86_64-el9-gcc14fp-opt/libarchive-env.sh
+          source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Mon/jsonmcpp/3.11.3/x86_64-el9-gcc14fp-opt/jsonmcpp-env.sh
+          source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Mon/poco/1.14.1/x86_64-el9-gcc14fp-opt/poco-env.sh
+          source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Mon/cli11/2.4.2/x86_64-el9-gcc14fp-opt/cli11-env.sh
+          source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Mon/libarchive/3.7.9/x86_64-el9-gcc14fp-opt/libarchive-env.sh
+          source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Mon/libbpf/1.5.0/x86_64-el9-gcc14fp-opt/libbpf-env.sh
+          source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Mon/libnuma/2.0.19/x86_64-el9-gcc14fp-opt/libnuma-env.sh
+          source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Mon/libtraceevent/1.8.4/x86_64-el9-gcc14fp-opt/libtraceevent-env.sh
+          source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Mon/flex/2.6.4/x86_64-el9-gcc14fp-opt/flex-env.sh
+          source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Mon/bison/3.8.2/x86_64-el9-gcc14fp-opt/bison-env.sh
+          source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Mon/Python/3.11.9/x86_64-el9-gcc14fp-opt/Python-env.sh
+          source /cvmfs/sft-nightlies.cern.ch/lcg/nightlies/dev4/Mon/perf/20250408/x86_64-el9-gcc14fp-opt/perf-env.sh
           mkdir build
           cd build
           echo "::group::CMakeConfig"
-          cmake ..
+          cmake -DPERF_DIR=${PERF__HOME} ..
           echo "::group::Compile"
           make VERBOSE=1 -k

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,35 +145,15 @@ if(NOT SERVER_ONLY)
   target_include_directories(adaptyst PUBLIC ${Boost_INCLUDE_DIRS})
   target_include_directories(adaptystserv PUBLIC ${Boost_INCLUDE_DIRS})
 
-  find_library(LIBNUMA
-    NAMES numa
-    DOC "libnuma")
-
-  if(LIBNUMA)
-    message(STATUS "Found libnuma: ${LIBNUMA}")
-
-    find_path(LIBNUMA_INCLUDE
-      NAMES numa.h
-      PATH_SUFFIXES include
-      DOC "libnuma header directory"
-    )
-
-    if (LIBNUMA_INCLUDE)
-      message(STATUS "Found numa.h inside ${LIBNUMA_INCLUDE}")
-      set(LIBNUMA_AVAILABLE TRUE)
-    else()
-      message(STATUS "numa.h not found, compiling without libnuma support")
-      set(LIBNUMA_AVAILABLE FALSE)
-    endif()
-  else()
-    message(STATUS "libnuma not found, compiling without libnuma support")
-    set(LIBNUMA_AVAILABLE FALSE)
-  endif()
-
-  if(LIBNUMA_AVAILABLE)
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(NUMA numa)
+  if(NUMA_FOUND)
+    message(STATUS "Found libnuma: ${NUMA_LINK_LIBRARIES}  ${NUMA_INCLUDE_DIRS}")
     target_compile_definitions(adaptyst PRIVATE LIBNUMA_AVAILABLE)
-    target_include_directories(adaptyst PUBLIC ${LIBNUMA_INCLUDE})
-    target_link_libraries(adaptyst PUBLIC numa)
+    target_include_directories(adaptyst PRIVATE ${NUMA_INCLUDE_DIRS})
+    target_link_libraries(adaptyst PUBLIC ${NUMA_LINK_LIBRARIES})
+  else()
+    message(STATUS "numa not found, compiling without libnuma support")
   endif()
 
   target_link_libraries(adaptyst PUBLIC adaptystserv)


### PR DESCRIPTION
…ystem locations

the target_link_libraries command was missing the '-L path/to/numa' flag and incidentally worked for /usr/lib/libnuma or similar

The error message is

```
[100%] Linking CXX executable adaptyst
/cvmfs/sft.cern.ch/lcg/releases/binutils/2.40-acaab/x86_64-el9/bin/ld: cannot find -lnuma: No such file or directory
collect2: error: ld returned 1 exit status
make[6]: *** [CMakeFiles/adaptyst.dir/build.make:199: adaptyst] Error 1
make[5]: *** [CMakeFiles/Makefile2:139: CMakeFiles/adaptyst.dir/all] Error 2
make[4]: *** [Makefile:136: all] Error 2
```