### PR TITLE
CMake: require also Boost::process

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,8 @@ if(NOT SERVER_ONLY)
   target_compile_definitions(adaptyst PRIVATE ADAPTYST_SCRIPT_PATH="${ADAPTYST_SCRIPT_PATH}")
   target_compile_definitions(adaptyst PRIVATE ADAPTYST_CONFIG_FILE="${ADAPTYST_CONFIG_PATH}")
 
-  find_package(Boost REQUIRED program_options process)
+  find_package(Boost REQUIRED program_options CONFIG
+               OPTIONAL_COMPONENTS process)
 
   if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.30")
     message(STATUS "Found Boost: headers inside ${Boost_INCLUDE_DIRS}, version ${Boost_VERSION_STRING}")
@@ -136,7 +137,7 @@ if(NOT SERVER_ONLY)
   target_link_libraries(adaptyst PUBLIC nlohmann_json::nlohmann_json)
   target_link_libraries(adaptyst PUBLIC Poco::Foundation Poco::Net)
   target_link_libraries(adaptyst PUBLIC CLI11::CLI11)
-  target_link_libraries(adaptyst PUBLIC Boost::program_options Boost::process)
+  target_link_libraries(adaptyst PUBLIC Boost::program_options $<TARGET_NAME_IF_EXISTS:Boost::process>)
   target_link_libraries(adaptyst PUBLIC LibArchive::LibArchive)
 
   target_include_directories(adaptyst PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,7 @@ if(NOT SERVER_ONLY)
   target_link_libraries(adaptyst PUBLIC nlohmann_json::nlohmann_json)
   target_link_libraries(adaptyst PUBLIC Poco::Foundation Poco::Net)
   target_link_libraries(adaptyst PUBLIC CLI11::CLI11)
-  target_link_libraries(adaptyst PUBLIC Boost::program_options $<TARGET_NAME_IF_EXISTS:Boost::process>)
+  target_link_libraries(adaptyst PUBLIC Boost::headers Boost::program_options $<TARGET_NAME_IF_EXISTS:Boost::process>)
   target_link_libraries(adaptyst PUBLIC LibArchive::LibArchive)
 
   target_include_directories(adaptyst PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,7 @@ if(NOT SERVER_ONLY)
   target_compile_definitions(adaptyst PRIVATE ADAPTYST_SCRIPT_PATH="${ADAPTYST_SCRIPT_PATH}")
   target_compile_definitions(adaptyst PRIVATE ADAPTYST_CONFIG_FILE="${ADAPTYST_CONFIG_PATH}")
 
-  find_package(Boost REQUIRED program_options)
+  find_package(Boost REQUIRED program_options process)
 
   if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.30")
     message(STATUS "Found Boost: headers inside ${Boost_INCLUDE_DIRS}, version ${Boost_VERSION_STRING}")
@@ -136,7 +136,7 @@ if(NOT SERVER_ONLY)
   target_link_libraries(adaptyst PUBLIC nlohmann_json::nlohmann_json)
   target_link_libraries(adaptyst PUBLIC Poco::Foundation Poco::Net)
   target_link_libraries(adaptyst PUBLIC CLI11::CLI11)
-  target_link_libraries(adaptyst PUBLIC Boost::program_options)
+  target_link_libraries(adaptyst PUBLIC Boost::program_options Boost::process)
   target_link_libraries(adaptyst PUBLIC LibArchive::LibArchive)
 
   target_include_directories(adaptyst PUBLIC


### PR DESCRIPTION
Otherwise I am getting
```
[100%] Linking CXX executable adaptyst
/cvmfs/sft.cern.ch/lcg/releases/binutils/2.40-acaab/x86_64-el9/bin/ld: CMakeFiles/adaptyst.dir/src/requirements.cpp.o: in function `_GLOBAL__sub_I__ZN8adaptyst26PerfEventKernelSettingsReqC2ERi':
requirements.cpp:(.text.startup+0xe): undefined reference to `boost::process::v2::error::get_utf8_category()'
/cvmfs/sft.cern.ch/lcg/releases/binutils/2.40-acaab/x86_64-el9/bin/ld: requirements.cpp:(.text.startup+0x13): undefined reference to `boost::process::v2::error::get_exit_code_category()'
/cvmfs/sft.cern.ch/lcg/releases/binutils/2.40-acaab/x86_64-el9/bin/ld: requirements.cpp:(.text.startup+0x18): undefined reference to `boost::process::v2::get_shell_category()'
collect2: error: ld returned 1 exit status
```
(after #63 is applied)

This is with Boost 1.88
