### PR TITLE
Introduce a new versioning scheme

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,10 +95,13 @@ make-gentoo-docker-image:
         /kaniko/executor --context $CI_PROJECT_DIR --dockerfile $CI_PROJECT_DIR/Dockerfile --destination $IMAGE_DESTINATION --destination $IMAGE_DESTINATION_DETAILED
         echo "Image pushed successfully to ${IMAGE_DESTINATION} and ${IMAGE_DESTINATION_DETAILED}"
       else
-        export IMAGE_DESTINATION_DETAILED=$CI_REGISTRY/adaptyst/adaptyst:$CI_COMMIT_SHORT_SHA
-        /kaniko/executor --context $CI_PROJECT_DIR --dockerfile $CI_PROJECT_DIR/Dockerfile --destination $IMAGE_DESTINATION_DETAILED --no-push
+        /kaniko/executor --context $CI_PROJECT_DIR --dockerfile $CI_PROJECT_DIR/Dockerfile --tarPath adaptyst-docker.tar --no-push
         echo "Image built successfully"
       fi
+  artifacts:
+    paths:
+      - adaptyst-docker.tar
+    expire_in: 1 day
 
 # Based on https://gitlab.cern.ch/gitlabci-examples/build_docker_image/-/blob/master/.gitlab-ci.yml
 make-alma9-docker-image:
@@ -116,10 +119,13 @@ make-alma9-docker-image:
         /kaniko/executor --context $CI_PROJECT_DIR --dockerfile $CI_PROJECT_DIR/Dockerfile-alma9 --destination $IMAGE_DESTINATION --destination $IMAGE_DESTINATION_DETAILED
         echo "Image pushed successfully to ${IMAGE_DESTINATION} and ${IMAGE_DESTINATION_DETAILED}"
       else
-        export IMAGE_DESTINATION_DETAILED=$CI_REGISTRY/adaptyst/adaptyst:alma9-$CI_COMMIT_SHORT_SHA
-        /kaniko/executor --context $CI_PROJECT_DIR --dockerfile $CI_PROJECT_DIR/Dockerfile-alma9 --destination $IMAGE_DESTINATION_DETAILED --no-push
+        /kaniko/executor --context $CI_PROJECT_DIR --dockerfile $CI_PROJECT_DIR/Dockerfile-alma9 --tarPath adaptyst-docker-alma9.tar --no-push
         echo "Image built successfully"
       fi
+  artifacts:
+    paths:
+      - adaptyst-docker-alma9.tar
+    expire_in: 1 day
 
 make-apptainer-images:
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,7 @@ workflow:
 stages:
   - build
   - test
+  - images
   - deploy
 
 compile-gentoo:
@@ -84,7 +85,7 @@ make-gentoo-docker-image:
   image:
     name: gcr.io/kaniko-project/executor:debug
     entrypoint: [""]
-  stage: deploy
+  stage: images
   dependencies: []
   script:
     - echo "{\"auths\":{\"$CI_REGISTRY\":{\"username\":\"$CI_DEPLOY_USER\",\"password\":\"$CI_DEPLOY_PASSWORD\"}}}" > /kaniko/.docker/config.json
@@ -95,20 +96,16 @@ make-gentoo-docker-image:
         /kaniko/executor --context $CI_PROJECT_DIR --dockerfile $CI_PROJECT_DIR/Dockerfile --destination $IMAGE_DESTINATION --destination $IMAGE_DESTINATION_DETAILED
         echo "Image pushed successfully to ${IMAGE_DESTINATION} and ${IMAGE_DESTINATION_DETAILED}"
       else
-        /kaniko/executor --context $CI_PROJECT_DIR --dockerfile $CI_PROJECT_DIR/Dockerfile --tarPath adaptyst-docker.tar --no-push
+        /kaniko/executor --context $CI_PROJECT_DIR --dockerfile $CI_PROJECT_DIR/Dockerfile --no-push
         echo "Image built successfully"
       fi
-  artifacts:
-    paths:
-      - adaptyst-docker.tar
-    expire_in: 1 day
 
 # Based on https://gitlab.cern.ch/gitlabci-examples/build_docker_image/-/blob/master/.gitlab-ci.yml
 make-alma9-docker-image:
   image:
     name: gcr.io/kaniko-project/executor:debug
     entrypoint: [""]
-  stage: deploy
+  stage: images
   dependencies: []
   script:
     - echo "{\"auths\":{\"$CI_REGISTRY\":{\"username\":\"$CI_DEPLOY_USER\",\"password\":\"$CI_DEPLOY_PASSWORD\"}}}" > /kaniko/.docker/config.json
@@ -119,18 +116,14 @@ make-alma9-docker-image:
         /kaniko/executor --context $CI_PROJECT_DIR --dockerfile $CI_PROJECT_DIR/Dockerfile-alma9 --destination $IMAGE_DESTINATION --destination $IMAGE_DESTINATION_DETAILED
         echo "Image pushed successfully to ${IMAGE_DESTINATION} and ${IMAGE_DESTINATION_DETAILED}"
       else
-        /kaniko/executor --context $CI_PROJECT_DIR --dockerfile $CI_PROJECT_DIR/Dockerfile-alma9 --tarPath adaptyst-docker-alma9.tar --no-push
+        /kaniko/executor --context $CI_PROJECT_DIR --dockerfile $CI_PROJECT_DIR/Dockerfile-alma9 --no-push
         echo "Image built successfully"
       fi
-  artifacts:
-    paths:
-      - adaptyst-docker-alma9.tar
-    expire_in: 1 day
 
 make-apptainer-images:
   tags:
     - gentoo
-  stage: deploy
+  stage: images
   dependencies: []
   before_script:
     - echo $KERBEROS_PASSWORD | kinit ${KERBEROS_USER}@CERN.CH
@@ -143,15 +136,8 @@ make-apptainer-images:
         xrdcp -C auto --rm-bad-cksum -t 5 adaptyst-alma9.sif root://eosuser.cern.ch/$WEB_STORAGE/apptainer/adaptyst-alma9-$CI_COMMIT_TAG.sif
       fi
   after_script:
-    - |
-      if [[ -v CI_COMMIT_TAG ]]; then
-        rm -f adaptyst.sif adaptyst-alma9.sif
-      fi
+    - rm -f adaptyst.sif adaptyst-alma9.sif
     - kdestroy -A
-  artifacts:
-    paths:
-      - "*.sif"
-    expire_in: 1 day
 
 deploy-to-syclops-gentoo-profiling:
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,7 +72,7 @@ pages:
   dependencies:
     - doxygen-test
   rules:
-    - if: $CI_COMMIT_BRANCH == "main"
+    - if: $CI_COMMIT_TAG != null
   script:
     - mv docs/html public
   artifacts:
@@ -87,19 +87,18 @@ make-gentoo-docker-image:
   stage: deploy
   dependencies: []
   script:
-    - |
-      if [[ $CI_COMMIT_BRANCH == "main" ]]; then
-        export IMAGE_DESTINATION_NAMED=$CI_REGISTRY/adaptyst/adaptyst:latest
-      else
-        export IMAGE_DESTINATION_NAMED=$CI_REGISTRY/adaptyst/adaptyst:branch-$CI_COMMIT_BRANCH
-      fi
-      export IMAGE_DESTINATION=$CI_REGISTRY/adaptyst/adaptyst:commit-$CI_COMMIT_SHORT_SHA
-    # Prepare Kaniko configuration file
     - echo "{\"auths\":{\"$CI_REGISTRY\":{\"username\":\"$CI_DEPLOY_USER\",\"password\":\"$CI_DEPLOY_PASSWORD\"}}}" > /kaniko/.docker/config.json
-    # Build and push the image from the Dockerfile at the root of the project.
-    - /kaniko/executor --context $CI_PROJECT_DIR --dockerfile $CI_PROJECT_DIR/Dockerfile --destination $IMAGE_DESTINATION --destination $IMAGE_DESTINATION_NAMED --build-arg "JOBS=12"
-    # Print the full registry path of the pushed image
-    - echo "Image pushed successfully to ${IMAGE_DESTINATION} and ${IMAGE_DESTINATION_NAMED}"
+    - |
+      if [[ -v CI_COMMIT_TAG ]]; then
+        export IMAGE_DESTINATION=$CI_REGISTRY/adaptyst/adaptyst:latest
+        export IMAGE_DESTINATION_DETAILED=$CI_REGISTRY/adaptyst/adaptyst:$CI_COMMIT_TAG
+        /kaniko/executor --context $CI_PROJECT_DIR --dockerfile $CI_PROJECT_DIR/Dockerfile --destination $IMAGE_DESTINATION --destination $IMAGE_DESTINATION_DETAILED
+        echo "Image pushed successfully to ${IMAGE_DESTINATION} and ${IMAGE_DESTINATION_DETAILED}"
+      else
+        export IMAGE_DESTINATION_DETAILED=$CI_REGISTRY/adaptyst/adaptyst:$CI_COMMIT_SHORT_SHA
+        /kaniko/executor --context $CI_PROJECT_DIR --dockerfile $CI_PROJECT_DIR/Dockerfile --destination $IMAGE_DESTINATION_DETAILED --no-push
+        echo "Image built successfully"
+      fi
 
 # Based on https://gitlab.cern.ch/gitlabci-examples/build_docker_image/-/blob/master/.gitlab-ci.yml
 make-alma9-docker-image:
@@ -109,19 +108,18 @@ make-alma9-docker-image:
   stage: deploy
   dependencies: []
   script:
-    - |
-      if [[ $CI_COMMIT_BRANCH == "main" ]]; then
-        export IMAGE_DESTINATION_NAMED=$CI_REGISTRY/adaptyst/adaptyst:alma9-latest
-      else
-        export IMAGE_DESTINATION_NAMED=$CI_REGISTRY/adaptyst/adaptyst:alma9-branch-$CI_COMMIT_BRANCH
-      fi
-      export IMAGE_DESTINATION=$CI_REGISTRY/adaptyst/adaptyst:alma9-commit-$CI_COMMIT_SHORT_SHA
-    # Prepare Kaniko configuration file
     - echo "{\"auths\":{\"$CI_REGISTRY\":{\"username\":\"$CI_DEPLOY_USER\",\"password\":\"$CI_DEPLOY_PASSWORD\"}}}" > /kaniko/.docker/config.json
-    # Build and push the image from the Dockerfile at the root of the project.
-    - /kaniko/executor --context $CI_PROJECT_DIR --dockerfile $CI_PROJECT_DIR/Dockerfile-alma9 --destination $IMAGE_DESTINATION --destination $IMAGE_DESTINATION_NAMED
-    # Print the full registry path of the pushed image
-    - echo "Image pushed successfully to ${IMAGE_DESTINATION} and ${IMAGE_DESTINATION_NAMED}"
+    - |
+      if [[ -v CI_COMMIT_TAG ]]; then
+        export IMAGE_DESTINATION=$CI_REGISTRY/adaptyst/adaptyst:alma9-latest
+        export IMAGE_DESTINATION_DETAILED=$CI_REGISTRY/adaptyst/adaptyst:alma9-$CI_COMMIT_TAG
+        /kaniko/executor --context $CI_PROJECT_DIR --dockerfile $CI_PROJECT_DIR/Dockerfile-alma9 --destination $IMAGE_DESTINATION --destination $IMAGE_DESTINATION_DETAILED
+        echo "Image pushed successfully to ${IMAGE_DESTINATION} and ${IMAGE_DESTINATION_DETAILED}"
+      else
+        export IMAGE_DESTINATION_DETAILED=$CI_REGISTRY/adaptyst/adaptyst:alma9-$CI_COMMIT_SHORT_SHA
+        /kaniko/executor --context $CI_PROJECT_DIR --dockerfile $CI_PROJECT_DIR/Dockerfile-alma9 --destination $IMAGE_DESTINATION_DETAILED --no-push
+        echo "Image built successfully"
+      fi
 
 make-apptainer-images:
   tags:
@@ -134,20 +132,20 @@ make-apptainer-images:
     - sudo apptainer build --build-arg project_dir="$CI_PROJECT_DIR" --build-arg registry="$CI_REGISTRY" adaptyst.sif $CI_PROJECT_DIR/apptainer.def
     - sudo apptainer build --build-arg project_dir="$CI_PROJECT_DIR" --build-arg registry="$CI_REGISTRY" adaptyst-alma9.sif $CI_PROJECT_DIR/apptainer-alma9.def
     - |
-      if [[ $CI_COMMIT_BRANCH == "main" ]]; then
-        xrdfs root://eosuser.cern.ch mv $WEB_STORAGE/apptainer/adaptyst-latest.sif $WEB_STORAGE/apptainer/backup-adaptyst-latest.sif || true
-        xrdfs root://eosuser.cern.ch mv $WEB_STORAGE/apptainer/adaptyst-alma9-latest.sif $WEB_STORAGE/apptainer/backup-adaptyst-alma9-latest.sif || true
-        xrdcp -C auto --rm-bad-cksum -t 5 adaptyst.sif root://eosuser.cern.ch/$WEB_STORAGE/apptainer/adaptyst-latest.sif
-        xrdcp -C auto --rm-bad-cksum -t 5 adaptyst-alma9.sif root://eosuser.cern.ch/$WEB_STORAGE/apptainer/adaptyst-alma9-latest.sif
-      else
-        xrdfs root://eosuser.cern.ch mv $WEB_STORAGE/apptainer/adaptyst-$CI_COMMIT_BRANCH.sif $WEB_STORAGE/apptainer/backup-adaptyst-$CI_COMMIT_BRANCH.sif || true
-        xrdfs root://eosuser.cern.ch mv $WEB_STORAGE/apptainer/adaptyst-alma9-$CI_COMMIT_BRANCH.sif $WEB_STORAGE/apptainer/backup-adaptyst-alma9-$CI_COMMIT_BRANCH.sif || true
-        xrdcp -C auto --rm-bad-cksum -t 5 adaptyst.sif root://eosuser.cern.ch/$WEB_STORAGE/apptainer/adaptyst-$CI_COMMIT_BRANCH.sif
-        xrdcp -C auto --rm-bad-cksum -t 5 adaptyst-alma9.sif root://eosuser.cern.ch/$WEB_STORAGE/apptainer/adaptyst-alma9-$CI_COMMIT_BRANCH.sif
+      if [[ -v CI_COMMIT_TAG ]]; then
+        xrdcp -C auto --rm-bad-cksum -t 5 adaptyst.sif root://eosuser.cern.ch/$WEB_STORAGE/apptainer/adaptyst-$CI_COMMIT_TAG.sif
+        xrdcp -C auto --rm-bad-cksum -t 5 adaptyst-alma9.sif root://eosuser.cern.ch/$WEB_STORAGE/apptainer/adaptyst-alma9-$CI_COMMIT_TAG.sif
       fi
   after_script:
-    - rm -f adaptyst.sif adaptyst-alma9.sif
+    - |
+      if [[ -v CI_COMMIT_TAG ]]; then
+        rm -f adaptyst.sif adaptyst-alma9.sif
+      fi
     - kdestroy -A
+  artifacts:
+    paths:
+      - "*.sif"
+    expire_in: 1 day
 
 deploy-to-syclops-gentoo-profiling:
   tags:
@@ -155,7 +153,7 @@ deploy-to-syclops-gentoo-profiling:
   stage: deploy
   dependencies: []
   rules:
-    - if: $CI_COMMIT_BRANCH == "main"
+    - if: $CI_COMMIT_TAG != null
   script:
     - mkdir build && cd build
     - cmake $CI_PROJECT_DIR -G Ninja

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,9 +43,9 @@ find_package(CLI11 CONFIG REQUIRED)
 find_package(LibArchive REQUIRED)
 
 execute_process(
-  COMMAND git rev-parse --short HEAD
+  COMMAND git describe --tags
   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-  OUTPUT_VARIABLE GIT_COMMIT
+  OUTPUT_VARIABLE GIT_DESC_TAG
   OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 configure_file(src/version.cpp.in version.cpp @ONLY)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Adaptyst
 [![License: GNU GPL v2 only](https://img.shields.io/badge/license-GNU%20GPL%20v2%20only-blue)]()
-[![Version: 0.1.dev](https://img.shields.io/badge/version-0.1.dev-red)]()
+[![Version](https://img.shields.io/github/v/release/adaptyst/adaptyst?include_prereleases&label=version)]()
 
 A comprehensive and architecture-agnostic performance analysis tool (formerly AdaptivePerf).
 

--- a/src/version.cpp.in
+++ b/src/version.cpp.in
@@ -1,3 +1,3 @@
 namespace adaptyst {
-  const char *version = "0.1.dev+@GIT_COMMIT@";
+  const char *version = "@GIT_DESC_TAG@";
 };


### PR DESCRIPTION
This PR introduces a new versioning scheme to make Adaptyst releases cleaner and less confusing. After merging, git tags and GitHub releases will be used along with [semantic versioning](https://semver.org) instead of the current method of git commit hashes from the main branch. The PR also changes the organisation of the container images (the documentation will be updated accordingly).

For development versions, the following semantic-versioning-based scheme will be used: ```<version>-dev.XXXX.YYZ```, where ```XXXX``` is a year, ```YY``` is a month, and ```Z``` is a letter from "a" to "z" indicating subsequent releases in the given month.