### PR TITLE
Trigger CI only for PRs and tags + include releases link in README.md

### DIFF
--- a/.github/workflows/lcg.yaml
+++ b/.github/workflows/lcg.yaml
@@ -1,10 +1,12 @@
 name: linux
 
-# on: [push, pull_request]
-on: [push]
+on:
+  - push:
+      tags:
+        - v**
+  - pull_request
 
 jobs:
-
   default:
     runs-on: ubuntu-latest
     steps:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,8 +1,7 @@
 workflow:
   rules:
     - if: $CI_PIPELINE_SOURCE == "external_pull_request_event"
-      when: never
-    - when: always
+    - if: $CI_COMMIT_BRANCH == "main" && $CI_COMMIT_TAG != null
 
 stages:
   - build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Adaptyst
 [![License: GNU GPL v2 only](https://img.shields.io/badge/license-GNU%20GPL%20v2%20only-blue)]()
-[![Version](https://img.shields.io/github/v/release/adaptyst/adaptyst?include_prereleases&label=version)]()
+[![Version](https://img.shields.io/github/v/release/adaptyst/adaptyst?include_prereleases&label=version)](https://github.com/Adaptyst/Adaptyst/releases)
 
 A comprehensive and architecture-agnostic performance analysis tool (formerly AdaptivePerf).
 


### PR DESCRIPTION
This PR does what the title says. The CI behaviour change is motivated by limiting CI runs only to cases when these are strictly necessary.