### PR TITLE
Bugfixes 06/05/2025

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 workflow:
   rules:
-    - if: $CI_PIPELINE_SOURCE == "external_pull_request_event"
+    - if: $CI_PIPELINE_SOURCE == "external_pull_request_event" || $CI_PIPELINE_SOURCE == "web"
     - if: $CI_COMMIT_BRANCH == "main" && $CI_COMMIT_TAG != null
 
 stages:

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -64,11 +64,17 @@ namespace adaptyst {
       }
 
       if (this->notifiable) {
-        close(this->notify_pipe[1]);
+        close_fd(this->notify_pipe[1]);
       }
 
       waitpid(this->id, nullptr, 0);
 #endif
+    }
+  }
+
+  inline void Process::close_fd(int fd) {
+    if (fd != -1) {
+      close(fd);
     }
   }
 
@@ -134,8 +140,8 @@ namespace adaptyst {
     if (!this->stdout_redirect) {
       if (pipe(this->stdout_pipe) == -1) {
         if (this->notifiable) {
-          close(this->notify_pipe[0]);
-          close(this->notify_pipe[1]);
+          close_fd(this->notify_pipe[0]);
+          close_fd(this->notify_pipe[1]);
           this->notifiable = false;
         }
 
@@ -149,14 +155,14 @@ namespace adaptyst {
 
     if (pipe(this->stdin_pipe) == -1) {
       if (this->notifiable) {
-        close(this->notify_pipe[0]);
-        close(this->notify_pipe[1]);
+        close_fd(this->notify_pipe[0]);
+        close_fd(this->notify_pipe[1]);
         this->notifiable = false;
       }
 
       if (!this->stdout_redirect) {
-        close(this->stdout_pipe[0]);
-        close(this->stdout_pipe[1]);
+        close_fd(this->stdout_pipe[0]);
+        close_fd(this->stdout_pipe[1]);
       }
 
       throw Process::StartException();
@@ -175,19 +181,19 @@ namespace adaptyst {
       // copied (NOT shared!)
 
       if (this->notifiable) {
-        close(this->notify_pipe[1]);
+        close_fd(this->notify_pipe[1]);
         char buf;
         int bytes_read = 0;
         int received = ::read(this->notify_pipe[0], &buf, 1);
-        close(this->notify_pipe[0]);
+        close_fd(this->notify_pipe[0]);
 
         if (received <= 0 || buf != 0x03) {
           std::exit(Process::ERROR_START_PROFILE);
         }
       }
 
-      close(this->stdin_pipe[1]);
-      close(this->stdout_pipe[0]);
+      close_fd(this->stdin_pipe[1]);
+      close_fd(this->stdout_pipe[0]);
 
       fs::current_path(working_path);
 
@@ -203,7 +209,7 @@ namespace adaptyst {
           std::exit(Process::ERROR_STDERR_DUP2);
         }
 
-        close(stderr_fd);
+        close_fd(stderr_fd);
       }
 
       if (this->stdout_redirect) {
@@ -225,21 +231,21 @@ namespace adaptyst {
             std::exit(Process::ERROR_STDOUT_DUP2);
           }
 
-          close(stdout_fd);
+          close_fd(stdout_fd);
         }
       } else {
         if (dup2(this->stdout_pipe[1], STDOUT_FILENO) == -1) {
           std::exit(Process::ERROR_STDOUT_DUP2);
         }
 
-        close(this->stdout_pipe[1]);
+        close_fd(this->stdout_pipe[1]);
       }
 
       if (dup2(this->stdin_pipe[0], STDIN_FILENO) == -1) {
         std::exit(Process::ERROR_STDIN_DUP2);
       }
 
-      close(this->stdin_pipe[0]);
+      close_fd(this->stdin_pipe[0]);
 
       char *argv[this->command.size() + 1];
 
@@ -282,20 +288,20 @@ namespace adaptyst {
     }
 
     if (this->notifiable) {
-      close(this->notify_pipe[0]);
+      close_fd(this->notify_pipe[0]);
     }
 
-    close(this->stdin_pipe[0]);
+    close_fd(this->stdin_pipe[0]);
 
     if (this->stdout_redirect && this->stdout_fd != nullptr) {
-      close(*(this->stdout_fd));
+      close_fd(*(this->stdout_fd));
     } else if (!this->stdout_redirect) {
-      close(this->stdout_pipe[1]);
+      close_fd(this->stdout_pipe[1]);
     }
 
     if (forked == -1) {
       if (this->notifiable) {
-        close(this->notify_pipe[1]);
+        close_fd(this->notify_pipe[1]);
         this->notifiable = false;
       }
 

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -18,6 +18,7 @@ namespace adaptyst {
 
     this->command = command;
     this->stdout_redirect = false;
+    this->stdout_terminal = false;
     this->stderr_redirect = false;
     this->notifiable = false;
     this->started = false;

--- a/src/process.hpp
+++ b/src/process.hpp
@@ -36,6 +36,8 @@ namespace adaptyst {
     bool started;
     int id;
 
+    inline void close_fd(int fd);
+
   public:
     static const int ERROR_START_PROFILE = 200;
     static const int ERROR_STDOUT = 201;

--- a/src/profilers.cpp
+++ b/src/profilers.cpp
@@ -145,7 +145,7 @@ namespace adaptyst {
                      "syscalls:sys_exit_execve,syscalls:sys_exit_execveat,"
                      "sched:sched_process_fork,sched:sched_process_exit",
                      "--sorted-stream", "--pid=" + std::to_string(pid)};
-      argv_script = {this->perf_bin_path.string(), "script", "-s",
+      argv_script = {this->perf_bin_path.string(), "script", "-i", "-", "-s",
                      script_path + "/adaptyst-syscall-process.py",
                      "--demangle", "--demangle-kernel",
                      "--max-stack=" + std::to_string(this->max_stack)};
@@ -162,7 +162,7 @@ namespace adaptyst {
                      "--buffer-events", this->perf_event.options[2],
                      "--buffer-off-cpu-events", this->perf_event.options[3],
                      "--pid=" + std::to_string(pid)};
-      argv_script = {this->perf_bin_path.string(), "script", "-s",
+      argv_script = {this->perf_bin_path.string(), "script", "-i", "-", "-s",
                      script_path + "/adaptyst-process.py",
                      "--demangle", "--demangle-kernel",
                      "--max-stack=" + std::to_string(this->max_stack)};
@@ -177,7 +177,7 @@ namespace adaptyst {
                      this->perf_event.name + "/period=" + this->perf_event.options[0] + "/",
                      "--buffer-events", this->perf_event.options[1],
                      "--pid=" + std::to_string(pid)};
-      argv_script = {this->perf_bin_path.string(), "script", "-s",
+      argv_script = {this->perf_bin_path.string(), "script", "-i", "-", "-s",
                      script_path + "/adaptyst-process.py",
                      "--demangle", "--demangle-kernel",
                      "--max-stack=" + std::to_string(this->max_stack)};


### PR DESCRIPTION
This PR fixes the following bugs:

- ```redirect_terminal``` is uninitialised in ```Process```, causing e.g. "perf record" to erroneously redirect its output to stdout rather than to "perf script"
- "perf script" is run without explicitly specifying its input as stdin (this hasn't caused issues so far, but better safe than sorry here)
- Some ```close()``` syscalls in ```Process``` are called with fd = -1 which is invalid