### PR TITLE
Remove regex processing of existing environment variables in Process

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 workflow:
   rules:
     - if: $CI_PIPELINE_SOURCE == "external_pull_request_event" || $CI_PIPELINE_SOURCE == "web"
-    - if: $CI_COMMIT_BRANCH == "main" && $CI_COMMIT_TAG != null
+    - if: $CI_COMMIT_TAG != null
 
 stages:
   - build

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -2,7 +2,6 @@
 // Copyright (C) CERN. See LICENSE for details.
 
 #include "process.hpp"
-#include <regex>
 #include <boost/algorithm/string.hpp>
 
 #ifdef BOOST_OS_UNIX
@@ -37,17 +36,25 @@ namespace adaptyst {
     char **cur_existing_env_entry = environ;
 
     while (*cur_existing_env_entry != nullptr) {
-      std::smatch match;
-      std::string cur_entry(*cur_existing_env_entry);
+      char *cur_entry = *cur_existing_env_entry;
 
-      if (!std::regex_match(cur_entry,
-                            match,
-                            std::regex("^(.+)\\=(.*)$"))) {
+      int sep_index = -1;
+      for (int i = 0; cur_entry[i]; i++) {
+        if (cur_entry[i] == '=') {
+          sep_index = i;
+          break;
+        }
+      }
+
+      if (sep_index == -1) {
         continue;
       }
 
-      if (this->env.find(match[1]) == this->env.end()) {
-        this->env[match[1]] = match[2];
+      std::string key(cur_entry, sep_index);
+      std::string value(cur_entry + sep_index + 1);
+
+      if (this->env.find(key) == this->env.end()) {
+        this->env[key] = value;
       }
 
       cur_existing_env_entry++;


### PR DESCRIPTION
In some cases in ```Process```, processing values from ```environ``` through the regex functions in the C++ standard library makes Adaptyst appear to freeze for long time. Therefore, this PR removes regex usage from ```Process``` and introduces manual parsing instead.

*Additionally, the PR makes a small change to the GitLab CI pipeline configuration to make sure that the pipeline runs automatically for new tags.*