### PR TITLE
Fix missing Doxygen documentation

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -187,7 +187,7 @@ FULL_PATH_NAMES        = YES
 # will be relative from the directory where doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        = ../src
+STRIP_FROM_PATH        = ../src ../include
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which
@@ -946,7 +946,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = MAINPAGE.md ../src
+INPUT                  = MAINPAGE.md ../src ../include
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -521,7 +521,7 @@ TIMESTAMP              = NO
 # normally produced when WARNINGS is set to YES.
 # The default value is: NO.
 
-EXTRACT_ALL            = NO
+EXTRACT_ALL            = YES
 
 # If the EXTRACT_PRIVATE tag is set to YES, all private members of a class will
 # be included in the documentation.
@@ -994,48 +994,12 @@ FILE_PATTERNS          = *.c \
                          *.cppm \
                          *.c++ \
                          *.c++m \
-                         *.java \
-                         *.ii \
-                         *.ixx \
-                         *.ipp \
-                         *.i++ \
-                         *.inl \
-                         *.idl \
-                         *.ddl \
-                         *.odl \
                          *.h \
                          *.hh \
                          *.hxx \
                          *.hpp \
                          *.h++ \
-                         *.ixx \
-                         *.l \
-                         *.cs \
-                         *.d \
-                         *.php \
-                         *.php4 \
-                         *.php5 \
-                         *.phtml \
-                         *.inc \
-                         *.m \
-                         *.markdown \
-                         *.md \
-                         *.mm \
-                         *.dox \
-                         *.py \
-                         *.pyw \
-                         *.f90 \
-                         *.f95 \
-                         *.f03 \
-                         *.f08 \
-                         *.f18 \
-                         *.f \
-                         *.for \
-                         *.vhd \
-                         *.vhdl \
-                         *.ucf \
-                         *.qsf \
-                         *.ice
+                         *.md
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.
@@ -1050,7 +1014,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                =
+EXCLUDE                = ../docs
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded
@@ -1360,7 +1324,7 @@ HTML_STYLESHEET        =
 # documentation.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_EXTRA_STYLESHEET  = diagrams.css
+HTML_EXTRA_STYLESHEET  =
 
 # The HTML_EXTRA_FILES tag can be used to specify one or more extra images or
 # other source files which should be copied to the HTML output directory. Note

--- a/docs/MAINPAGE.md
+++ b/docs/MAINPAGE.md
@@ -4,35 +4,6 @@ SPDX-License-Identifier: CC-BY-4.0
 -->
 
 # Adaptyst documentation
-Welcome to the Adaptyst documentation for contributors!
+Welcome to the Adaptyst documentation for developers and contributors!
 
-To get started, please:
-1. Read "Communication between the frontend, server, clients, and profilers" below.
-2. Go through the source code, starting with ```entrypoint.hpp```/```entrypoint.cpp``` inside ```src``` and ```src/server``` and using the documentation along the way to get to know the specific classes and functions (you can browse "Namespaces" and "Classes" for this purpose).
-
-### Preprocessor definitions
-These are the CMake-set Adaptyst-specific (i.e. non-Boost) preprocessor definitions you should be aware of:
-* ```SERVER_ONLY```: set when Adaptyst is compiled only with the backend component (i.e. adaptyst-server).
-* ```LIBNUMA_AVAILABLE```: set when Adaptyst is compiled with libnuma support.
-* ```ADAPTYST_CONFIG_FILE```: the path to the Adaptyst config file, CMake sets it to ```/etc/adaptyst.conf``` by default.
-* ```ADAPTYST_SCRIPT_PATH```: the path to the directory with Adaptyst "perf" Python scripts, CMake sets it to ```/opt/adaptyst``` by default.
-
-### Tests
-Making sure the tests pass and updating these when needed is crucial during the Adaptyst development. They are implemented using [the GoogleTest framework](https://github.com/google/googletest) and their codes are stored inside the ```test``` directory.
-
-To enable tests in the Adaptyst compilation, run ```build.sh``` with ```-DENABLE_TESTS=ON```. Afterwards, run ```ctest``` inside the newly-created build directory every time you want to run the tests.
-
-### Communication between the frontend, server, clients, subclients, and profilers
-The backend (adaptyst-server) consists of the Server, Client, and Subclient components. The communication between these components and the frontend + profilers differs depending on whether adaptyst-server is run externally or internally. The diagrams below explain how this works for both cases.
-
-Please note the following:
-1. In both cases, the frontend additionally sends the received subclient connection instructions directly to each profiler before waiting for "start_profile".
-2. In case of adaptyst-server running externally, if "p code_paths.lst" is sent by the frontend during the file transfer stage, no code\_paths.lst file is actually created by the server. Instead, it consumes the received content (i.e. the list of source code paths) immediately to produce a source code archive.
-
-**If adaptyst-server is run externally with the frontend connecting to it via TCP, the communication between the frontend, profilers, and server components is as follows (each colour represents a machine; different-coloured blocks can therefore run on different machines, but they don't have to):**
-
-<img class="main_page_img" src="external.svg" alt="External adaptyst-server communication diagram" />
-
-**If adaptyst-server is run internally (i.e. as part of the ```adaptyst``` command) with the frontend connecting to it via file descriptors, the communication is as follows:**
-
-<img class="main_page_img" src="internal.svg" alt="Internal adaptyst-server communication diagram" />
+This is still work in progress, so some sections may be incomplete, please bear with us :)


### PR DESCRIPTION
The Doxygen documentation is missing substantial parts, including the module API pages. This PR fixes it.